### PR TITLE
Add AGENTS.md with Cursor Cloud environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Sorting Algorithm Visualizer: a single-module Maven **desktop GUI** app (one JVM) that
+pairs a JavaFX/AtlantaFX Settings window with a libGDX/LWJGL3 OpenGL canvas. Standard
+build/run/test commands live in `README.md` and `CONTRIBUTING.md` — use those; notes
+below only cover non-obvious, environment-specific caveats.
+
+### Toolchain
+- Requires **JDK 26+** (`pom.xml` sets `maven.compiler.release=26`). JDK 26 (Temurin) is
+  preinstalled and wired as the default `/usr/bin/java` via `update-alternatives`, so
+  `./mvnw`/`./build`/`./run` pick it up automatically. `JAVA_HOME` is also exported in
+  `~/.bashrc`. The stock system JDK is 21, which will NOT compile this project.
+- Use the Maven wrapper `./mvnw` (Maven 3.9.9); there is no system `mvn`.
+
+### Lint / test / build / run
+- Lint: `./mvnw spotless:check` (Google Java Format) and Error Prone run during `verify`.
+  Auto-fix with `./mvnw spotless:apply`.
+- Full check (matches CI): `./mvnw --batch-mode clean verify -Dspotless.check.skip=true`.
+  CI runs `spotless:check` as a separate step, then `verify` with the check skipped.
+- Tests are headless: JavaFX/TestFX use Monocle (`prism.order=sw`, headless glass),
+  configured in `pom.xml` surefire — no display needed for `mvn test`/`verify`.
+- Run the app: `./build` (or `./mvnw package`) then `./run` (needs `target/*.jar` +
+  `target/dependency/*`). `./run` accepts the README launch flags.
+
+### Running the GUI in the cloud VM
+- The app needs a display. Use `DISPLAY=:1` (the VNC desktop); Mesa provides software
+  OpenGL (llvmpipe), which is enough for the libGDX canvas. No physical GPU is required.
+- **Sound is unavailable** in the VM (no ALSA/MIDI device). On startup the app logs
+  `MidiUnavailableException` / `Sound system unavailable, running without audio` and
+  keeps running — this is expected, not a failure.
+- Closing the Settings window or pressing **Esc** on the canvas quits the whole app, so
+  avoid Esc during manual testing.
+- Two windows open (JavaFX Settings + libGDX canvas). Use Alt+Tab to switch between them;
+  they are not always tracked by `wmctrl`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the development environment for the Sorting Algorithm Visualizer (JDK 26 + Maven desktop app). Adds an `AGENTS.md` with durable, non-obvious cloud-specific notes for future agents. No application code changed.

## What was set up
- Installed **JDK 26 (Temurin)** and made it the default `java`/`javac` (system default is JDK 21, which cannot compile this project).
- Warmed Maven dependencies via the wrapper (`./mvnw`).

## Verification
- Lint: `./mvnw spotless:check` — tooling works (detects pre-existing formatting violations on `refactor/architecture`).
- Tests: `./mvnw --batch-mode clean verify -Dspotless.check.skip=true` — **307 tests, 0 failures** (includes headless JavaFX/TestFX Monocle smoke tests).
- Build: produces `target/sorting-visualizer.jar` + `target/dependency/*`.
- Run: launched `./run` on `DISPLAY=:1` (Mesa software GL). Ran Bubble Sort end-to-end; bars animated and metrics increased (542 → 1,629 → 4,451 → 7,777 comparisons) through to a fully sorted gradient. Sound (MIDI/ALSA) is unavailable in the VM and the app gracefully runs without audio.

[bubble_sort_animation_demo.mp4](https://cursor.com/agents/bc-1db42e88-6215-4ac4-9fe1-85d44604a1f2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbubble_sort_animation_demo.mp4)

[Bubble sort progressing - 4451 comparisons](https://cursor.com/agents/bc-1db42e88-6215-4ac4-9fe1-85d44604a1f2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbubblesort_t3_4451comparisons.webp)
[Sorted result gradient](https://cursor.com/agents/bc-1db42e88-6215-4ac4-9fe1-85d44604a1f2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbubblesort_t4_sorted.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1db42e88-6215-4ac4-9fe1-85d44604a1f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1db42e88-6215-4ac4-9fe1-85d44604a1f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

