### PR TITLE
docs: refresh README Controls to match current Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ Run one algorithm, or run a custom selection **in order** and optionally show a 
 
 | Control | Options |
 |---------|---------|
-| Array | Size up to 20 000; shuffle: random, reverse, almost sorted, sorted |
+| Array | Size 3–100 000; shuffle: random, reverse, almost sorted, sorted |
 | Sorting | Algorithm picker, run-all with drag-reorder dialog, shuffle type |
 | Speed | Five levels (steps per frame) |
 | Appearance | Gradient presets + custom colors |
-| Visualization | 30 modes; image path with validation for image viz |
-| Sound | MIDI tones mapped to values; mute anytime |
-| Metrics | Sorted %, comparisons, swaps, main/aux writes, estimated time |
-| Session | Cancel mid-run; optional end-of-run comparison table (persisted prefs) |
+| Visualization | 30 modes; Customize (Cube); image path with validation for image viz |
+| Sound | MIDI tones mapped to values; sound-effects checkbox |
+| Display | Show measurements (sorted %, comparisons, swaps, main/aux writes, est. time); comparison table after run-all; export CSV |
+| Session | Cancel mid-run; prefs persist across launches |
 
 ## Build from source
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the README Controls table so it matches the live app on `refactor/architecture`:

- Array size range is **3–100 000** (`SettingsDefaults.ARRAY_SIZE_MAX`), not 20 000 (that value is only the lag warning threshold)
- Sound row reflects the sound-effects checkbox
- Visualization mentions Cube Customize
- Display row covers measurements, comparison table, and CSV export

No code changes. Base retargeted from the cloud setup branch to `refactor/architecture`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7535037-3e9f-4f3e-8d40-2bc46c7c293a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7535037-3e9f-4f3e-8d40-2bc46c7c293a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

