### PR TITLE
chore(deps): batch Dependabot updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up JDK 26
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 26
@@ -26,9 +26,9 @@ jobs:
   sbom:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up JDK 26
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 26
@@ -36,7 +36,7 @@ jobs:
       - name: Generate CycloneDX SBOM
         run: mvn --batch-mode -Prelease package -DskipTests
       - name: Upload SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cyclonedx-sbom
           path: target/bom.json

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.release>26</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <errorprone.version>2.50.0</errorprone.version>
-        <javafx.version>26.0.1</javafx.version>
+        <javafx.version>26.0.2</javafx.version>
         <atlantafx.version>2.1.0</atlantafx.version>
         <animatefx.version>1.3.0</animatefx.version>
         <testfx.version>4.0.18</testfx.version>
@@ -36,7 +36,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
                 <configuration>
                     <compilerArgs>
                         <arg>-XDcompilePolicy=simple</arg>
@@ -81,7 +81,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.4.2</version>
+                <version>3.5.1</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -98,7 +98,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.11.0</version>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>
@@ -146,7 +146,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-assembly-plugin</artifactId>
-                        <version>3.4.2</version>
+                        <version>3.8.0</version>
                         <executions>
                             <execution>
                                 <phase>package</phase>
@@ -197,7 +197,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-assembly-plugin</artifactId>
-                        <version>3.4.2</version>
+                        <version>3.8.0</version>
                         <executions>
                             <execution>
                                 <id>jpackage-fat-jar</id>
@@ -225,7 +225,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
-                        <version>3.5.0</version>
+                        <version>3.6.3</version>
                         <executions>
                             <execution>
                                 <id>jpackage-linux-app-image</id>
@@ -322,13 +322,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.4</version>
+            <version>6.1.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.tngtech.archunit</groupId>
             <artifactId>archunit-junit5</artifactId>
-            <version>1.3.0</version>
+            <version>1.4.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
- Batches all open Dependabot PRs (#44–#54) into one change to avoid merge conflicts
- Maven: JavaFX 26.0.2, JUnit 6.1.2, ArchUnit 1.4.2, compiler/jar/dependency/assembly/exec plugin bumps
- GitHub Actions: checkout@v7, setup-java@v5, upload-artifact@v7

## Test plan
- [x] Local `./mvnw --batch-mode clean verify -Dspotless.check.skip=true`
- [ ] CI build + sbom pass