### PR TITLE
fix: use exclusive fullscreen so desktop panels hide

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Optional flags (after the JAR name; `fullscreen` wins over `portrait`):
 
 | Flag | Effect |
 |------|--------|
-| `fullscreen` | Fullscreen visualization |
+| `fullscreen` | Exclusive fullscreen visualization (hides desktop panels) |
 | `portrait` | Tall ~9:16 window |
 | `--display=N` | Visualization on display `N` (1-based; default is 2 when multiple monitors exist) |
 

--- a/src/main/java/io/github/compilerstuck/control/DesktopLauncher.java
+++ b/src/main/java/io/github/compilerstuck/control/DesktopLauncher.java
@@ -18,7 +18,6 @@ public final class DesktopLauncher {
     AppIcons.installApplicationIcons();
     JavaFxBootstrap.start();
 
-    Rectangle bounds = DisplayBounds.resolveBounds(LaunchArgs.display());
     boolean fullscreen = LaunchArgs.fullscreen();
     boolean portrait = LaunchArgs.portrait();
 
@@ -32,16 +31,19 @@ public final class DesktopLauncher {
     config.setWindowSizeLimits(AppConfig.MIN_WINDOW_WIDTH, AppConfig.MIN_WINDOW_HEIGHT, -1, -1);
 
     if (fullscreen) {
-      config.setDecorated(false);
-      config.setWindowedMode(Math.max(1, bounds.width), Math.max(1, bounds.height));
-      config.setWindowPosition(bounds.x, bounds.y);
+      // Exclusive fullscreen (GLFW monitor) so desktop panels auto-hide on Linux/Windows/macOS.
+      config.setFullscreenMode(
+          Lwjgl3ApplicationConfiguration.getDisplayMode(
+              DisplayBounds.resolveMonitor(LaunchArgs.display())));
     } else if (portrait) {
+      Rectangle bounds = DisplayBounds.resolveBounds(LaunchArgs.display());
       Dimension portraitDim = DisplayBounds.portraitSize(bounds);
       config.setWindowedMode(portraitDim.width, portraitDim.height);
       int x = bounds.x + Math.max(0, (bounds.width - portraitDim.width) / 2);
       int y = bounds.y + Math.max(0, (bounds.height - portraitDim.height) / 2);
       config.setWindowPosition(x, y);
     } else {
+      Rectangle bounds = DisplayBounds.resolveBounds(LaunchArgs.display());
       config.setWindowedMode(Math.max(1, bounds.width), Math.max(1, bounds.height));
       config.setWindowPosition(bounds.x, bounds.y);
       config.setMaximized(true);

--- a/src/main/java/io/github/compilerstuck/control/DisplayBounds.java
+++ b/src/main/java/io/github/compilerstuck/control/DisplayBounds.java
@@ -1,5 +1,7 @@
 package io.github.compilerstuck.control;
 
+import com.badlogic.gdx.Graphics.Monitor;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
 import io.github.compilerstuck.control.config.AppConfig;
 import java.awt.Dimension;
 import java.awt.GraphicsDevice;
@@ -8,9 +10,9 @@ import java.awt.Rectangle;
 import java.util.logging.Logger;
 
 /**
- * Resolves monitor bounds and portrait window size for the libGDX visualization window (AWT).
- * Settings placement uses JavaFX {@code Screen.getPrimary().getVisualBounds()} instead - AWT and
- * JavaFX coordinates can disagree on multi-monitor / HiDPI Linux.
+ * Resolves monitor bounds / GLFW monitors and portrait window size for the libGDX visualization
+ * window. Settings placement uses JavaFX {@code Screen.getPrimary().getVisualBounds()} instead -
+ * AWT and JavaFX coordinates can disagree on multi-monitor / HiDPI Linux.
  */
 public final class DisplayBounds {
   private static final Logger LOGGER = Logger.getLogger(DisplayBounds.class.getName());
@@ -27,25 +29,44 @@ public final class DisplayBounds {
   public static Rectangle resolveBounds(int displayIndex) {
     GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
     GraphicsDevice[] devices = ge.getScreenDevices();
+    int listIndex = resolveListIndex(displayIndex, devices.length);
+    GraphicsDevice device = listIndex >= 0 ? devices[listIndex] : ge.getDefaultScreenDevice();
+    return device.getDefaultConfiguration().getBounds();
+  }
+
+  /**
+   * Resolves the GLFW/libGDX {@link Monitor} for exclusive fullscreen, using the same {@code
+   * --display=} selection rules as {@link #resolveBounds(int)}.
+   */
+  public static Monitor resolveMonitor(int displayIndex) {
+    Monitor[] monitors = Lwjgl3ApplicationConfiguration.getMonitors();
+    int listIndex = resolveListIndex(displayIndex, monitors.length);
+    return listIndex >= 0
+        ? monitors[listIndex]
+        : Lwjgl3ApplicationConfiguration.getPrimaryMonitor();
+  }
+
+  /**
+   * Maps a 1-based {@code --display=} index to a 0-based list index. {@code displayIndex <= 0}
+   * prefers the secondary monitor when more than one is available. Returns {@code -1} to mean "use
+   * the platform primary/default".
+   */
+  static int resolveListIndex(int displayIndex, int count) {
     int index = displayIndex;
     if (index <= 0) {
       // Prefer the secondary monitor when present so Settings can own the primary.
-      index = devices.length > 1 ? 2 : 0;
+      index = count > 1 ? 2 : 0;
     }
-    GraphicsDevice device = ge.getDefaultScreenDevice();
-    if (index > 0 && index <= devices.length) {
-      device = devices[index - 1];
-    } else if (index > 0) {
+    if (index > 0 && index <= count) {
+      return index - 1;
+    }
+    if (index > 0) {
       final int requested = index;
+      final int available = count;
       LOGGER.warning(
-          () ->
-              "Display "
-                  + requested
-                  + " not found ("
-                  + devices.length
-                  + " available); using primary");
+          () -> "Display " + requested + " not found (" + available + " available); using primary");
     }
-    return device.getDefaultConfiguration().getBounds();
+    return -1;
   }
 
   /**

--- a/src/test/java/io/github/compilerstuck/control/DisplayBoundsTest.java
+++ b/src/test/java/io/github/compilerstuck/control/DisplayBoundsTest.java
@@ -1,0 +1,29 @@
+package io.github.compilerstuck.control;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class DisplayBoundsTest {
+
+  @Test
+  void defaultOnSingleMonitorUsesPrimary() {
+    assertEquals(-1, DisplayBounds.resolveListIndex(0, 1));
+  }
+
+  @Test
+  void defaultOnMultiMonitorPrefersSecondary() {
+    assertEquals(1, DisplayBounds.resolveListIndex(0, 2));
+  }
+
+  @Test
+  void explicitOneBasedIndex() {
+    assertEquals(0, DisplayBounds.resolveListIndex(1, 2));
+    assertEquals(1, DisplayBounds.resolveListIndex(2, 2));
+  }
+
+  @Test
+  void outOfRangeFallsBackToPrimary() {
+    assertEquals(-1, DisplayBounds.resolveListIndex(3, 2));
+  }
+}


### PR DESCRIPTION
## Summary
- Switch the `fullscreen` launch flag from borderless windowed mode to GLFW/libGDX exclusive fullscreen so desktop panels (e.g. Cinnamon on Linux Mint) auto-hide.
- Share `--display=N` monitor selection between AWT windowed bounds and GLFW fullscreen monitors, with unit tests for the index logic.

## Test plan
- [ ] `./build && ./run fullscreen` — visualization covers the monitor and Mint/Cinnamon panel hides
- [ ] Esc / Settings still work; closing Settings quits the app
- [ ] Multi-monitor: `./run fullscreen --display=1` and `--display=2` land on the expected screens
- [ ] Default (no flag) and `portrait` modes still open as before