### PR TITLE
feat: optional five-second start delay

### DIFF
--- a/src/main/java/io/github/compilerstuck/control/AppContext.java
+++ b/src/main/java/io/github/compilerstuck/control/AppContext.java
@@ -53,6 +53,7 @@ public final class AppContext {
   private int speedLevel = SettingsDefaults.DEFAULT_SPEED_LEVEL; // 1–5, default Normal
   private int stepsPerFrame = SettingsDefaults.stepsPerFrame(SettingsDefaults.DEFAULT_SPEED_LEVEL);
   private boolean perfStatsEnabled;
+  private boolean fiveSecondStartDelay;
 
   public AppContext(
       ArrayController arrayController,
@@ -66,6 +67,7 @@ public final class AppContext {
     this.size = this.preferences.getArraySize();
     this.speedLevel = this.preferences.getSpeedLevel();
     this.perfStatsEnabled = this.preferences.isPerfStats();
+    this.fiveSecondStartDelay = this.preferences.isFiveSecondStartDelay();
     if (sessionManager != null) {
       sessionManager.setFrameGate(frameGate);
     }
@@ -86,6 +88,7 @@ public final class AppContext {
     preferences.setPrintMeasurements(stateManager.shouldPrintMeasurements());
     preferences.setShowComparisonTable(stateManager.shouldShowComparisonTable());
     preferences.setPerfStats(perfStatsEnabled);
+    preferences.setFiveSecondStartDelay(fiveSecondStartDelay);
     if (colorGradient != null) {
       preferences.setGradientName(colorGradient.getName());
       if (colorGradient.getColor1() != null) {
@@ -356,6 +359,16 @@ public final class AppContext {
   public void setPerfStatsEnabled(boolean enabled) {
     perfStatsEnabled = enabled;
     preferences.setPerfStats(enabled);
+    preferences.save();
+  }
+
+  public boolean isFiveSecondStartDelay() {
+    return fiveSecondStartDelay;
+  }
+
+  public void setFiveSecondStartDelay(boolean enabled) {
+    fiveSecondStartDelay = enabled;
+    preferences.setFiveSecondStartDelay(enabled);
     preferences.save();
   }
 

--- a/src/main/java/io/github/compilerstuck/control/config/AppConfig.java
+++ b/src/main/java/io/github/compilerstuck/control/config/AppConfig.java
@@ -43,6 +43,9 @@ public final class AppConfig {
   public static final int DELAY_AFTER_SORT_RESULT = 1500;
   public static final int SETUP_DELAY = 500;
 
+  /** Longer setup delay when the user needs time to switch to the visualization window. */
+  public static final int SETUP_DELAY_LONG = 5000;
+
   /**
    * Shuffle animation length in seconds. Pacing uses a fixed visual-step budget (not the sort speed
    * setting).

--- a/src/main/java/io/github/compilerstuck/control/config/AppConfig.java
+++ b/src/main/java/io/github/compilerstuck/control/config/AppConfig.java
@@ -36,7 +36,8 @@ public final class AppConfig {
   // Frame rate and rendering (display cadence; sort pacing uses FrameGate)
   public static final int TARGET_FRAME_RATE = 60;
 
-  public static final int MAX_TEXT_SIZE = 50;
+  /** Upper clamp for FreeType HUD font generation (safety against pathological window widths). */
+  public static final int MAX_TEXT_SIZE = 128;
 
   // Timing (milliseconds)
   public static final int DELAY_BETWEEN_ALGORITHMS = 500;

--- a/src/main/java/io/github/compilerstuck/control/config/SettingsDefaults.java
+++ b/src/main/java/io/github/compilerstuck/control/config/SettingsDefaults.java
@@ -27,6 +27,7 @@ public final class SettingsDefaults {
   public static final boolean DEFAULT_RUN_ALL = false;
   public static final String DEFAULT_RUN_ALL_ENTRIES = "";
   public static final boolean DEFAULT_PERF_STATS = false;
+  public static final boolean DEFAULT_FIVE_SECOND_START_DELAY = false;
 
   /** JSON map of visualizationId → settings object (see VisualizationSettingsCodec). */
   public static final String DEFAULT_VISUAL_SETTINGS_BY_ID = "{}";

--- a/src/main/java/io/github/compilerstuck/control/config/UserPreferences.java
+++ b/src/main/java/io/github/compilerstuck/control/config/UserPreferences.java
@@ -38,6 +38,7 @@ public final class UserPreferences {
   private static final String KEY_RUN_ALL = "runAll";
   private static final String KEY_RUN_ALL_ENTRIES = "runAllEntries";
   private static final String KEY_PERF_STATS = "perfStats";
+  private static final String KEY_FIVE_SECOND_START_DELAY = "fiveSecondStartDelay";
   private static final String KEY_VISUAL_SETTINGS_BY_ID = "visualSettingsById";
   private static final int CURRENT_DEFAULTS_VERSION = 1;
 
@@ -60,6 +61,7 @@ public final class UserPreferences {
   private boolean runAll = SettingsDefaults.DEFAULT_RUN_ALL;
   private String runAllEntries = SettingsDefaults.DEFAULT_RUN_ALL_ENTRIES;
   private boolean perfStats = SettingsDefaults.DEFAULT_PERF_STATS;
+  private boolean fiveSecondStartDelay = SettingsDefaults.DEFAULT_FIVE_SECOND_START_DELAY;
   private String visualSettingsById = SettingsDefaults.DEFAULT_VISUAL_SETTINGS_BY_ID;
 
   public static UserPreferences load() {
@@ -98,6 +100,9 @@ public final class UserPreferences {
       prefs.runAllEntries = SettingsDefaults.DEFAULT_RUN_ALL_ENTRIES;
     }
     prefs.perfStats = node.getBoolean(KEY_PERF_STATS, SettingsDefaults.DEFAULT_PERF_STATS);
+    prefs.fiveSecondStartDelay =
+        node.getBoolean(
+            KEY_FIVE_SECOND_START_DELAY, SettingsDefaults.DEFAULT_FIVE_SECOND_START_DELAY);
     prefs.visualSettingsById =
         node.get(KEY_VISUAL_SETTINGS_BY_ID, SettingsDefaults.DEFAULT_VISUAL_SETTINGS_BY_ID);
     if (prefs.visualSettingsById == null) {
@@ -130,6 +135,7 @@ public final class UserPreferences {
     node.putBoolean(KEY_RUN_ALL, runAll);
     node.put(KEY_RUN_ALL_ENTRIES, runAllEntries != null ? runAllEntries : "");
     node.putBoolean(KEY_PERF_STATS, perfStats);
+    node.putBoolean(KEY_FIVE_SECOND_START_DELAY, fiveSecondStartDelay);
     node.put(
         KEY_VISUAL_SETTINGS_BY_ID,
         visualSettingsById != null
@@ -278,6 +284,14 @@ public final class UserPreferences {
 
   public void setPerfStats(boolean perfStats) {
     this.perfStats = perfStats;
+  }
+
+  public boolean isFiveSecondStartDelay() {
+    return fiveSecondStartDelay;
+  }
+
+  public void setFiveSecondStartDelay(boolean fiveSecondStartDelay) {
+    this.fiveSecondStartDelay = fiveSecondStartDelay;
   }
 
   public String getVisualSettingsById() {

--- a/src/main/java/io/github/compilerstuck/control/render/asset/AppAssets.java
+++ b/src/main/java/io/github/compilerstuck/control/render/asset/AppAssets.java
@@ -6,6 +6,7 @@ import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator;
 import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator.FreeTypeFontParameter;
 import com.badlogic.gdx.utils.Disposable;
+import io.github.compilerstuck.control.config.AppConfig;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,21 +34,16 @@ public final class AppAssets implements Disposable {
     }
   }
 
-  /** Nearest cached size (same behavior as legacy {@code GdxRenderSystem.fontFor}). */
+  /**
+   * Returns a FreeType font at the exact requested pixel size (rounded, clamped to {@code
+   * 1..AppConfig.MAX_TEXT_SIZE}). Generated fonts are cached by size.
+   */
   public BitmapFont font(float sizePx) {
-    int nearest = FONT_SIZES[0];
-    float best = Math.abs(sizePx - nearest);
-    for (int s : FONT_SIZES) {
-      float d = Math.abs(sizePx - s);
-      if (d < best) {
-        best = d;
-        nearest = s;
-      }
-    }
-    BitmapFont font = fonts.get(nearest);
+    int size = Math.max(1, Math.min(AppConfig.MAX_TEXT_SIZE, Math.round(sizePx)));
+    BitmapFont font = fonts.get(size);
     if (font == null) {
-      font = createFont(nearest);
-      fonts.put(nearest, font);
+      font = createFont(size);
+      fonts.put(size, font);
     }
     return font;
   }

--- a/src/main/java/io/github/compilerstuck/control/screen/VisualizerScreen.java
+++ b/src/main/java/io/github/compilerstuck/control/screen/VisualizerScreen.java
@@ -44,7 +44,7 @@ public final class VisualizerScreen implements Screen {
             }
             if (keycode == Input.Keys.ESCAPE) {
               SortingStateManager state = game.stateManager();
-              if (state != null && state.isRunning()) {
+              if (state != null && (state.isRunning() || game.setupDelayRemaining() >= 0f)) {
                 game.cancelSorting();
               } else {
                 focusSettingsWindow();
@@ -174,6 +174,11 @@ public final class VisualizerScreen implements Screen {
   private void handleIdleState(float delta) {
     SortingStateManager stateManager = game.stateManager();
     if (game.setupDelayRemaining() >= 0f) {
+      if (!stateManager.shouldContinueExecution()) {
+        game.finishSession(true);
+        game.publishThenDraw(delta);
+        return;
+      }
       game.publishThenDraw(delta);
       game.setSetupDelayRemaining(game.setupDelayRemaining() - delta);
       if (game.setupDelayRemaining() <= 0f) {
@@ -183,7 +188,12 @@ public final class VisualizerScreen implements Screen {
     } else if (stateManager.requestedStart()) {
       stateManager.setShowResults(false);
       stateManager.setStartRequested(false);
-      game.setSetupDelayRemaining(AppConfig.SETUP_DELAY / 1000f);
+      stateManager.setContinueExecution(true);
+      int delayMs =
+          game.appContext() != null && game.appContext().isFiveSecondStartDelay()
+              ? AppConfig.SETUP_DELAY_LONG
+              : AppConfig.SETUP_DELAY;
+      game.setSetupDelayRemaining(delayMs / 1000f);
       if (game.appContext() != null) {
         game.appContext().settingsBridge().setInputsEnabled(false);
       }

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/OptionsSection.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/OptionsSection.java
@@ -42,7 +42,18 @@ public final class OptionsSection {
               }
             });
 
-    VBox display = new VBox(SettingsLayout.GAP_SM, measurements, comparison);
+    CheckBox startDelay = new CheckBox(SettingsStrings.FIVE_SECOND_START_DELAY);
+    startDelay.setSelected(displayVm.isFiveSecondStartDelay());
+    startDelay
+        .selectedProperty()
+        .addListener(
+            (obs, old, selected) -> {
+              if (selected != displayVm.isFiveSecondStartDelay()) {
+                displayVm.setFiveSecondStartDelay(selected);
+              }
+            });
+
+    VBox display = new VBox(SettingsLayout.GAP_SM, measurements, comparison, startDelay);
     display.setId(DisplaySection.ROOT_ID);
 
     Node sound = SoundSection.build(soundVm);
@@ -66,6 +77,14 @@ public final class OptionsSection {
                     comparison.setSelected(value);
                   }
                 });
+          } else if (DisplayViewModel.PROP_FIVE_SECOND_START_DELAY.equals(evt.getPropertyName())) {
+            boolean value = Boolean.TRUE.equals(evt.getNewValue());
+            VmBindings.runFx(
+                () -> {
+                  if (startDelay.isSelected() != value) {
+                    startDelay.setSelected(value);
+                  }
+                });
           }
         });
 
@@ -76,6 +95,11 @@ public final class OptionsSection {
         DisplayViewModel.PROP_INPUTS_ENABLED);
     VmBindings.bindInputsEnabled(
         comparison,
+        displayVm::isInputsEnabled,
+        displayVm::addPropertyChangeListener,
+        DisplayViewModel.PROP_INPUTS_ENABLED);
+    VmBindings.bindInputsEnabled(
+        startDelay,
         displayVm::isInputsEnabled,
         displayVm::addPropertyChangeListener,
         DisplayViewModel.PROP_INPUTS_ENABLED);

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SettingsStrings.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SettingsStrings.java
@@ -96,6 +96,7 @@ public final class SettingsStrings {
   public static final String SOUND_EFFECTS = "Sound effects";
   public static final String SHOW_MEASUREMENTS = "Show measurements";
   public static final String SHOW_COMPARISON_TABLE = "Show comparison table";
+  public static final String FIVE_SECOND_START_DELAY = "5 second start delay";
   public static final String SHOW_PERF_STATS = "Show render performance stats";
   public static final String SHUFFLE = "Shuffle";
   public static final String SWATCH_HINT = "Click a swatch to edit";

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/vm/DisplayViewModel.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/vm/DisplayViewModel.java
@@ -15,6 +15,7 @@ public final class DisplayViewModel {
 
   public static final String PROP_PRINT_MEASUREMENTS = "printMeasurements";
   public static final String PROP_SHOW_COMPARISON_TABLE = "showComparisonTable";
+  public static final String PROP_FIVE_SECOND_START_DELAY = "fiveSecondStartDelay";
   public static final String PROP_CAN_EXPORT = "canExport";
   public static final String PROP_INPUTS_ENABLED = "inputsEnabled";
 
@@ -23,12 +24,14 @@ public final class DisplayViewModel {
 
   private boolean printMeasurements;
   private boolean showComparisonTable;
+  private boolean fiveSecondStartDelay;
   private boolean inputsEnabled = true;
 
   public DisplayViewModel(AppContext app) {
     this.app = app;
     this.printMeasurements = app.getStateManager().shouldPrintMeasurements();
     this.showComparisonTable = app.getStateManager().shouldShowComparisonTable();
+    this.fiveSecondStartDelay = app.isFiveSecondStartDelay();
   }
 
   public boolean isPrintMeasurements() {
@@ -58,6 +61,20 @@ public final class DisplayViewModel {
     app.setShowComparisonTable(show);
     pcs.firePropertyChange(PROP_SHOW_COMPARISON_TABLE, old, show);
     pcs.firePropertyChange(PROP_CAN_EXPORT, null, canExport());
+  }
+
+  public boolean isFiveSecondStartDelay() {
+    return fiveSecondStartDelay;
+  }
+
+  public void setFiveSecondStartDelay(boolean enabled) {
+    if (!inputsEnabled || fiveSecondStartDelay == enabled) {
+      return;
+    }
+    boolean old = fiveSecondStartDelay;
+    fiveSecondStartDelay = enabled;
+    app.setFiveSecondStartDelay(enabled);
+    pcs.firePropertyChange(PROP_FIVE_SECOND_START_DELAY, old, enabled);
   }
 
   public boolean canExport() {

--- a/src/test/java/io/github/compilerstuck/control/config/SettingsDefaultsTest.java
+++ b/src/test/java/io/github/compilerstuck/control/config/SettingsDefaultsTest.java
@@ -19,6 +19,7 @@ class SettingsDefaultsTest {
     assertEquals(3, SettingsDefaults.DEFAULT_SPEED_LEVEL);
     assertFalse(SettingsDefaults.DEFAULT_MUTED);
     assertFalse(SettingsDefaults.DEFAULT_PERF_STATS);
+    assertFalse(SettingsDefaults.DEFAULT_FIVE_SECOND_START_DELAY);
     assertEquals("{}", SettingsDefaults.DEFAULT_VISUAL_SETTINGS_BY_ID);
 
     assertEquals(3, SettingsDefaults.ARRAY_SIZE_MIN);

--- a/src/test/java/io/github/compilerstuck/control/config/UserPreferencesTest.java
+++ b/src/test/java/io/github/compilerstuck/control/config/UserPreferencesTest.java
@@ -43,6 +43,7 @@ class UserPreferencesTest {
     assertEquals("", prefs.getRunAllEntries());
     assertTrue(prefs.getRunAllEntriesList().isEmpty());
     assertFalse(prefs.isPerfStats());
+    assertFalse(prefs.isFiveSecondStartDelay());
   }
 
   @Test
@@ -61,6 +62,7 @@ class UserPreferencesTest {
             new RunAllEntryPref("bubble-sort", true),
             new RunAllEntryPref("quicksort-middle", false)));
     prefs.setPerfStats(true);
+    prefs.setFiveSecondStartDelay(true);
     prefs.save(node);
 
     UserPreferences loaded = UserPreferences.load(node);
@@ -79,6 +81,7 @@ class UserPreferencesTest {
     assertEquals("quicksort-middle", entries.get(1).id());
     assertFalse(entries.get(1).selected());
     assertTrue(loaded.isPerfStats());
+    assertTrue(loaded.isFiveSecondStartDelay());
   }
 
   @Test

--- a/src/test/java/io/github/compilerstuck/control/ui/settingsfx/vm/DisplayViewModelTest.java
+++ b/src/test/java/io/github/compilerstuck/control/ui/settingsfx/vm/DisplayViewModelTest.java
@@ -23,12 +23,16 @@ class DisplayViewModelTest {
   void togglesUpdateStateManager() {
     assertTrue(vm.isPrintMeasurements());
     assertFalse(vm.isShowComparisonTable());
+    assertFalse(vm.isFiveSecondStartDelay());
 
     vm.setPrintMeasurements(false);
     assertFalse(fx.app.getStateManager().shouldPrintMeasurements());
 
     vm.setShowComparisonTable(true);
     assertTrue(fx.app.getStateManager().shouldShowComparisonTable());
+
+    vm.setFiveSecondStartDelay(true);
+    assertTrue(fx.app.isFiveSecondStartDelay());
   }
 
   @Test
@@ -42,5 +46,7 @@ class DisplayViewModelTest {
     vm.setInputsEnabled(false);
     vm.setShowComparisonTable(true);
     assertFalse(vm.isShowComparisonTable());
+    vm.setFiveSecondStartDelay(true);
+    assertFalse(vm.isFiveSecondStartDelay());
   }
 }

--- a/src/test/java/io/github/compilerstuck/control/ui/settingsfx/vm/PersistenceViewModelTest.java
+++ b/src/test/java/io/github/compilerstuck/control/ui/settingsfx/vm/PersistenceViewModelTest.java
@@ -26,8 +26,10 @@ class PersistenceViewModelTest {
   void displayTogglesPersistOnAppContext() {
     fx.app.setPrintMeasurements(false);
     fx.app.setShowComparisonTable(true);
+    fx.app.setFiveSecondStartDelay(true);
     assertFalse(fx.app.getPreferences().isPrintMeasurements());
     assertTrue(fx.app.getPreferences().isShowComparisonTable());
+    assertTrue(fx.app.getPreferences().isFiveSecondStartDelay());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Add a settings option for a 5s setup delay before sorting starts, so users can switch to the visualization window in time
- Allow Esc to cancel during the setup delay countdown
- Generate FreeType HUD fonts at exact requested sizes (clamped to 1..128) instead of snapping to a fixed size ladder

## Test plan
- [ ] Enable **Five second start delay** in Settings → Options, start a sort, confirm ~5s wait before shuffle/sort
- [ ] Disable the option, start a sort, confirm the shorter default delay
- [ ] Press Esc during the countdown and confirm the run cancels and inputs re-enable
- [ ] Restart the app and confirm the preference persists
- [ ] Resize the visualization window and confirm HUD text scales cleanly (no clipped/oversized glyphs)