### PR TITLE
feat: equalize sort duration, wider speed range, and Settings UI polish

### DIFF
--- a/src/main/java/io/github/compilerstuck/control/AppContext.java
+++ b/src/main/java/io/github/compilerstuck/control/AppContext.java
@@ -54,6 +54,7 @@ public final class AppContext {
   private int stepsPerFrame = SettingsDefaults.stepsPerFrame(SettingsDefaults.DEFAULT_SPEED_LEVEL);
   private boolean perfStatsEnabled;
   private boolean fiveSecondStartDelay;
+  private boolean equalizeSortDuration;
 
   public AppContext(
       ArrayController arrayController,
@@ -68,8 +69,13 @@ public final class AppContext {
     this.speedLevel = this.preferences.getSpeedLevel();
     this.perfStatsEnabled = this.preferences.isPerfStats();
     this.fiveSecondStartDelay = this.preferences.isFiveSecondStartDelay();
+    this.equalizeSortDuration = this.preferences.isEqualizeSortDuration();
     if (sessionManager != null) {
       sessionManager.setFrameGate(frameGate);
+      sessionManager.setEqualizeSupport(
+          () -> equalizeSortDuration,
+          () -> SettingsDefaults.equalizedDurationSec(speedLevel),
+          () -> delayContext);
     }
     applySpeedLevel();
   }
@@ -89,6 +95,7 @@ public final class AppContext {
     preferences.setShowComparisonTable(stateManager.shouldShowComparisonTable());
     preferences.setPerfStats(perfStatsEnabled);
     preferences.setFiveSecondStartDelay(fiveSecondStartDelay);
+    preferences.setEqualizeSortDuration(equalizeSortDuration);
     if (colorGradient != null) {
       preferences.setGradientName(colorGradient.getName());
       if (colorGradient.getColor1() != null) {
@@ -369,6 +376,16 @@ public final class AppContext {
   public void setFiveSecondStartDelay(boolean enabled) {
     fiveSecondStartDelay = enabled;
     preferences.setFiveSecondStartDelay(enabled);
+    preferences.save();
+  }
+
+  public boolean isEqualizeSortDuration() {
+    return equalizeSortDuration;
+  }
+
+  public void setEqualizeSortDuration(boolean enabled) {
+    equalizeSortDuration = enabled;
+    preferences.setEqualizeSortDuration(enabled);
     preferences.save();
   }
 

--- a/src/main/java/io/github/compilerstuck/control/AppContext.java
+++ b/src/main/java/io/github/compilerstuck/control/AppContext.java
@@ -50,7 +50,7 @@ public final class AppContext {
   private Runnable shutdownHandler;
   private SettingsBridge settingsBridge = SettingsBridge.NOOP;
 
-  private int speedLevel = SettingsDefaults.DEFAULT_SPEED_LEVEL; // 1–5, default Normal
+  private int speedLevel = SettingsDefaults.DEFAULT_SPEED_LEVEL; // 1–10, default Normal
   private int stepsPerFrame = SettingsDefaults.stepsPerFrame(SettingsDefaults.DEFAULT_SPEED_LEVEL);
   private boolean perfStatsEnabled;
   private boolean fiveSecondStartDelay;
@@ -154,9 +154,9 @@ public final class AppContext {
     return speedLevel;
   }
 
-  /** Applies speed level 1–5 as steps granted per draw frame. */
-  public void setSpeedLevel(int level1to5) {
-    this.speedLevel = SettingsDefaults.clampSpeedLevel(level1to5);
+  /** Applies speed level 1–10 as steps granted per draw frame. */
+  public void setSpeedLevel(int level1to10) {
+    this.speedLevel = SettingsDefaults.clampSpeedLevel(level1to10);
     applySpeedLevel();
     preferences.setSpeedLevel(this.speedLevel);
     preferences.save();

--- a/src/main/java/io/github/compilerstuck/control/DesktopLauncher.java
+++ b/src/main/java/io/github/compilerstuck/control/DesktopLauncher.java
@@ -25,8 +25,10 @@ public final class DesktopLauncher {
     config.setTitle("Sorting Algorithm Visualizer - Visualization");
     config.useVsync(true);
     config.setForegroundFPS(AppConfig.TARGET_FRAME_RATE);
-    // GL 3.0 (emulated by desktop OpenGL 3.2) required for mesh hardware instancing.
-    config.setOpenGLEmulation(Lwjgl3ApplicationConfiguration.GLEmulation.GL30, 3, 2);
+    // GLES 3.0 emulation needs desktop GL 3.3+: libGDX routes glVertexAttribDivisor via GL33.
+    config.setOpenGLEmulation(Lwjgl3ApplicationConfiguration.GLEmulation.GL30, 3, 3);
+    // Default is 16-bit depth; World3D quads/boxes z-fight into black triangles without 24-bit.
+    config.setDepthBits(24);
     config.setWindowIcon("logo.png");
     config.setWindowSizeLimits(AppConfig.MIN_WINDOW_WIDTH, AppConfig.MIN_WINDOW_HEIGHT, -1, -1);
 

--- a/src/main/java/io/github/compilerstuck/control/config/AppConfig.java
+++ b/src/main/java/io/github/compilerstuck/control/config/AppConfig.java
@@ -17,10 +17,17 @@ public final class AppConfig {
 
   public static final int MIN_WINDOW_HEIGHT = 360;
 
-  /** Minimum settings frame size so 1/4-area windows remain usable on small screens. */
-  public static final int SETTINGS_MIN_WIDTH = 480;
+  /** Minimum settings frame size so a stacked one-pager remains usable on small screens. */
+  public static final int SETTINGS_MIN_WIDTH = 560;
 
   public static final int SETTINGS_MIN_HEIGHT = 360;
+
+  /**
+   * Viewport width below which the Settings body stacks columns vertically instead of side-by-side.
+   * Measured against the ScrollPane viewport (already inset by shell padding); a 720-wide scene
+   * stays side-by-side.
+   */
+  public static final int SETTINGS_STACK_BREAKPOINT = 640;
 
   /**
    * Fallback settings size when the primary screen is unavailable. Live size is 3/4 of {@code

--- a/src/main/java/io/github/compilerstuck/control/config/AppConfig.java
+++ b/src/main/java/io/github/compilerstuck/control/config/AppConfig.java
@@ -56,6 +56,27 @@ public final class AppConfig {
   /** Frame-gate steps fired across one shuffle animation ({@link #SHUFFLE_DURATION_SEC}). */
   public static final int SHUFFLE_VISUAL_STEPS = 1000;
 
+  /**
+   * Max wall time for the silent dry-run that counts visual steps before an equalized sort. On
+   * timeout, equalization is skipped for that algorithm.
+   */
+  public static final long EQUALIZE_DRY_RUN_TIMEOUT_MS = 2000L;
+
+  /**
+   * Soft cap on equalize step credits granted per draw frame (plain {@code delay()} algorithms).
+   * Prevents a single frame from executing hundreds of thousands of visualized ops.
+   */
+  public static final int EQUALIZE_MAX_STEPS_PER_FRAME = 500;
+
+  /**
+   * Approx bar-update budget per frame when batching {@code delayFrame} algorithms (e.g. Gravity
+   * rewrites all {@code n} bars each beat). Cap beats/frame as {@code budget / n}.
+   */
+  public static final int EQUALIZE_FRAME_BEAT_ELEMENT_BUDGET = 250_000;
+
+  /** Upper bound on batched frame-beats granted in one draw frame. */
+  public static final int EQUALIZE_MAX_FRAME_BEATS_PER_FRAME = 64;
+
   // Visualization
   public static final int RESULTS_TABLE_BACKGROUND = 15;
   public static final int RESULTS_TABLE_TEXT_COLOR = 255;
@@ -81,10 +102,60 @@ public final class AppConfig {
     return Math.max(1, Math.round(SHUFFLE_VISUAL_STEPS * deltaSeconds / SHUFFLE_DURATION_SEC));
   }
 
-  // Text positioning
+  /**
+   * Lower-bound wall time for {@code frameBeats} whole-frame paces ({@code delayFrame}), assuming
+   * {@link #TARGET_FRAME_RATE}.
+   */
+  public static float equalizeFrameFloorSec(int frameBeats) {
+    if (frameBeats <= 0) {
+      return 0f;
+    }
+    return frameBeats / (float) TARGET_FRAME_RATE;
+  }
+
+  /**
+   * Effective equalize target: slider duration, but never shorter than the {@code delayFrame}
+   * floor.
+   */
+  public static float effectiveEqualizeTargetSec(float sliderTargetSec, int frameBeats) {
+    return Math.max(Math.max(0f, sliderTargetSec), equalizeFrameFloorSec(frameBeats));
+  }
+
+  /**
+   * Steps to grant this frame so {@code totalSteps} complete in {@code effectiveTargetSec}. Used
+   * when equalize-sort-duration mode is active (schedule correction may pass remaining steps/time).
+   */
+  public static int equalizedSortStepsForDelta(
+      float deltaSeconds, int totalSteps, float effectiveTargetSec) {
+    if (totalSteps <= 0) {
+      return 1;
+    }
+    if (deltaSeconds <= 0f || effectiveTargetSec <= 0f) {
+      return 1;
+    }
+    return Math.max(1, Math.round(totalSteps * deltaSeconds / effectiveTargetSec));
+  }
+
+  /**
+   * Max {@code delayFrame} beats to batch into one published frame for an array of {@code
+   * arrayLength}, keeping roughly {@link #EQUALIZE_FRAME_BEAT_ELEMENT_BUDGET} element updates per
+   * frame.
+   */
+  public static int equalizeMaxFrameBeatsPerFrame(int arrayLength) {
+    int n = Math.max(1, arrayLength);
+    int byBudget = EQUALIZE_FRAME_BEAT_ELEMENT_BUDGET / n;
+    return Math.max(1, Math.min(EQUALIZE_MAX_FRAME_BEATS_PER_FRAME, byBudget));
+  }
+
+  // Text positioning (design px at {@link #WINDOW_RATIO_WIDTH}; use {@link #scaleToWidth})
   public static final float TEXT_X_OFFSET = 5.0f;
   public static final float TEXT_Y_OFFSET = 23.0f;
   public static final float LINE_HEIGHT_OFFSET = 20.0f;
+  public static final float WATERMARK_TEXT_SIZE = 25.0f;
+  public static final float PERF_TEXT_SIZE = 16.0f;
+  public static final float PERF_LINE_HEIGHT = 18.0f;
+  public static final float PERF_MARGIN = 8.0f;
   public static final float TABLE_COLUMN_WIDTH_RATIO = 1.0f / 7.0f;
   public static final float TABLE_TOP_ROW = 50.0f;
+  public static final float TABLE_CELL_PADDING = 10.0f;
 }

--- a/src/main/java/io/github/compilerstuck/control/config/SettingsDefaults.java
+++ b/src/main/java/io/github/compilerstuck/control/config/SettingsDefaults.java
@@ -12,7 +12,7 @@ public final class SettingsDefaults {
   public static final String DEFAULT_ALGORITHM_ID = "quicksort-middle";
   public static final String DEFAULT_VISUALIZATION_ID = "bars";
   public static final int DEFAULT_ARRAY_SIZE = 1280;
-  public static final int DEFAULT_SPEED_LEVEL = 3;
+  public static final int DEFAULT_SPEED_LEVEL = 5;
   public static final boolean DEFAULT_MUTED = false;
 
   /** Phase 4 additive defaults (missing prefs keys resolve to these, no version bump). */
@@ -42,10 +42,10 @@ public final class SettingsDefaults {
   public static final int ARRAY_SIZE_HIGH_WARNING_THRESHOLD = 20_000;
 
   public static final int SPEED_LEVEL_MIN = 1;
-  public static final int SPEED_LEVEL_MAX = 5;
+  public static final int SPEED_LEVEL_MAX = 10;
 
-  /** Speed levels 1–5 → steps granted per draw frame. */
-  private static final int[] STEPS_PER_FRAME = {1, 5, 25, 200, 2000};
+  /** Speed levels 1–10 → steps granted per draw frame (same min/max as the old 5-step scale). */
+  private static final int[] STEPS_PER_FRAME = {1, 2, 5, 12, 25, 50, 100, 250, 750, 2000};
 
   private SettingsDefaults() {}
 
@@ -57,7 +57,7 @@ public final class SettingsDefaults {
     return Math.max(SPEED_LEVEL_MIN, Math.min(SPEED_LEVEL_MAX, level));
   }
 
-  /** Steps granted per draw frame for a clamped speed level (1–5). */
+  /** Steps granted per draw frame for a clamped speed level (1–10). */
   public static int stepsPerFrame(int speedLevel) {
     int level = clampSpeedLevel(speedLevel);
     return STEPS_PER_FRAME[level - 1];

--- a/src/main/java/io/github/compilerstuck/control/config/SettingsDefaults.java
+++ b/src/main/java/io/github/compilerstuck/control/config/SettingsDefaults.java
@@ -28,6 +28,7 @@ public final class SettingsDefaults {
   public static final String DEFAULT_RUN_ALL_ENTRIES = "";
   public static final boolean DEFAULT_PERF_STATS = false;
   public static final boolean DEFAULT_FIVE_SECOND_START_DELAY = false;
+  public static final boolean DEFAULT_EQUALIZE_SORT_DURATION = true;
 
   /** JSON map of visualizationId → settings object (see VisualizationSettingsCodec). */
   public static final String DEFAULT_VISUAL_SETTINGS_BY_ID = "{}";
@@ -47,6 +48,13 @@ public final class SettingsDefaults {
   /** Speed levels 1–10 → steps granted per draw frame (same min/max as the old 5-step scale). */
   private static final int[] STEPS_PER_FRAME = {1, 2, 5, 12, 25, 50, 100, 250, 750, 2000};
 
+  /**
+   * Speed levels 1–10 → target sort duration in seconds while equalize-sort-duration mode is on.
+   */
+  private static final float[] EQUALIZED_DURATION_SEC = {
+    30f, 20f, 15f, 12f, 10f, 8f, 6f, 4f, 3f, 2f
+  };
+
   private SettingsDefaults() {}
 
   public static int clampArraySize(int size) {
@@ -61,5 +69,27 @@ public final class SettingsDefaults {
   public static int stepsPerFrame(int speedLevel) {
     int level = clampSpeedLevel(speedLevel);
     return STEPS_PER_FRAME[level - 1];
+  }
+
+  /** Target wall-clock sort duration (seconds) for a clamped speed level when equalizing. */
+  public static float equalizedDurationSec(int speedLevel) {
+    int level = clampSpeedLevel(speedLevel);
+    return EQUALIZED_DURATION_SEC[level - 1];
+  }
+
+  /**
+   * Compact tick label for the speed slider: steps/frame (e.g. {@code 25}, {@code 2k}) or equalized
+   * duration (e.g. {@code 10s}).
+   */
+  public static String speedTickLabel(int speedLevel, boolean equalizeDuration) {
+    int level = clampSpeedLevel(speedLevel);
+    if (equalizeDuration) {
+      return Math.round(EQUALIZED_DURATION_SEC[level - 1]) + "s";
+    }
+    int steps = STEPS_PER_FRAME[level - 1];
+    if (steps >= 1000) {
+      return (steps / 1000) + "k";
+    }
+    return Integer.toString(steps);
   }
 }

--- a/src/main/java/io/github/compilerstuck/control/config/UserPreferences.java
+++ b/src/main/java/io/github/compilerstuck/control/config/UserPreferences.java
@@ -39,6 +39,7 @@ public final class UserPreferences {
   private static final String KEY_RUN_ALL_ENTRIES = "runAllEntries";
   private static final String KEY_PERF_STATS = "perfStats";
   private static final String KEY_FIVE_SECOND_START_DELAY = "fiveSecondStartDelay";
+  private static final String KEY_EQUALIZE_SORT_DURATION = "equalizeSortDuration";
   private static final String KEY_VISUAL_SETTINGS_BY_ID = "visualSettingsById";
   private static final int CURRENT_DEFAULTS_VERSION = 1;
 
@@ -62,6 +63,7 @@ public final class UserPreferences {
   private String runAllEntries = SettingsDefaults.DEFAULT_RUN_ALL_ENTRIES;
   private boolean perfStats = SettingsDefaults.DEFAULT_PERF_STATS;
   private boolean fiveSecondStartDelay = SettingsDefaults.DEFAULT_FIVE_SECOND_START_DELAY;
+  private boolean equalizeSortDuration = SettingsDefaults.DEFAULT_EQUALIZE_SORT_DURATION;
   private String visualSettingsById = SettingsDefaults.DEFAULT_VISUAL_SETTINGS_BY_ID;
 
   public static UserPreferences load() {
@@ -103,6 +105,9 @@ public final class UserPreferences {
     prefs.fiveSecondStartDelay =
         node.getBoolean(
             KEY_FIVE_SECOND_START_DELAY, SettingsDefaults.DEFAULT_FIVE_SECOND_START_DELAY);
+    prefs.equalizeSortDuration =
+        node.getBoolean(
+            KEY_EQUALIZE_SORT_DURATION, SettingsDefaults.DEFAULT_EQUALIZE_SORT_DURATION);
     prefs.visualSettingsById =
         node.get(KEY_VISUAL_SETTINGS_BY_ID, SettingsDefaults.DEFAULT_VISUAL_SETTINGS_BY_ID);
     if (prefs.visualSettingsById == null) {
@@ -136,6 +141,7 @@ public final class UserPreferences {
     node.put(KEY_RUN_ALL_ENTRIES, runAllEntries != null ? runAllEntries : "");
     node.putBoolean(KEY_PERF_STATS, perfStats);
     node.putBoolean(KEY_FIVE_SECOND_START_DELAY, fiveSecondStartDelay);
+    node.putBoolean(KEY_EQUALIZE_SORT_DURATION, equalizeSortDuration);
     node.put(
         KEY_VISUAL_SETTINGS_BY_ID,
         visualSettingsById != null
@@ -292,6 +298,14 @@ public final class UserPreferences {
 
   public void setFiveSecondStartDelay(boolean fiveSecondStartDelay) {
     this.fiveSecondStartDelay = fiveSecondStartDelay;
+  }
+
+  public boolean isEqualizeSortDuration() {
+    return equalizeSortDuration;
+  }
+
+  public void setEqualizeSortDuration(boolean equalizeSortDuration) {
+    this.equalizeSortDuration = equalizeSortDuration;
   }
 
   public String getVisualSettingsById() {

--- a/src/main/java/io/github/compilerstuck/control/model/ArrayController.java
+++ b/src/main/java/io/github/compilerstuck/control/model/ArrayController.java
@@ -134,6 +134,20 @@ public class ArrayController implements ArrayModel {
     metricsDirty = true;
   }
 
+  /**
+   * Copies {@code snapshot} into the working array without incrementing write/swap counters. Used
+   * to restore state after an equalize dry-run.
+   */
+  public void restoreContents(int[] snapshot) {
+    if (snapshot == null || snapshot.length != length) {
+      throw new IllegalArgumentException("snapshot length must match array length");
+    }
+    System.arraycopy(snapshot, 0, array, 0, length);
+    resetMarkers();
+    markMetricsDirty();
+    bumpVisualRevision();
+  }
+
   public void resetArray() {
     for (int i = 0; i < length; i++) {
       array[i] = i;

--- a/src/main/java/io/github/compilerstuck/control/model/EqualizePacing.java
+++ b/src/main/java/io/github/compilerstuck/control/model/EqualizePacing.java
@@ -1,0 +1,177 @@
+package io.github.compilerstuck.control.model;
+
+import io.github.compilerstuck.control.config.AppConfig;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Live equalize-sort-duration pacing shared between the sort worker and the render thread. When
+ * inactive, the render path uses the normal steps-per-frame speed setting.
+ *
+ * <p>Algorithms that use {@code delayFrame()} (e.g. Gravity Sort) are normally capped at one beat
+ * per published frame. Under equalization this class enables:
+ *
+ * <ul>
+ *   <li><b>Batching</b> when the slider target is below that floor — beats consume plain step
+ *       credits so multiple columns can share a frame (slightly chunkier, but hits the target).
+ *   <li><b>Stretching</b> when the target is above the floor — extra published frames are inserted
+ *       between beats so the run lasts ~the slider duration.
+ * </ul>
+ *
+ * <p>Grants are capped per frame so large arrays (e.g. Gravity at 100k) cannot pack thousands of
+ * heavy beats into one draw and freeze the UI. The run then takes longer than the slider target.
+ */
+public final class EqualizePacing {
+  private static final float MIN_REMAINING_SEC = 1e-3f;
+
+  private volatile boolean active;
+  private volatile int totalSteps;
+  private volatile int frameBeats;
+  private volatile float sliderTargetSec;
+  private volatile int maxStepsPerFrame = AppConfig.EQUALIZE_MAX_STEPS_PER_FRAME;
+  private volatile long startNanos;
+
+  private final AtomicInteger stepsConsumed = new AtomicInteger();
+  private final AtomicInteger frameBeatsConsumed = new AtomicInteger();
+
+  /** Fractional extra frames owed while stretching {@code delayFrame} beats. */
+  private double frameWaitDebt;
+
+  public boolean isActive() {
+    return active;
+  }
+
+  public int totalSteps() {
+    return totalSteps;
+  }
+
+  public int frameBeats() {
+    return frameBeats;
+  }
+
+  /** Slider target duration (seconds); also the wall-clock goal when batching/stretching. */
+  public float effectiveTargetSec() {
+    return sliderTargetSec;
+  }
+
+  public float sliderTargetSec() {
+    return sliderTargetSec;
+  }
+
+  public int maxStepsPerFrame() {
+    return maxStepsPerFrame;
+  }
+
+  public int stepsConsumed() {
+    return stepsConsumed.get();
+  }
+
+  public int frameBeatsConsumed() {
+    return frameBeatsConsumed.get();
+  }
+
+  /**
+   * True when the slider asks for a shorter run than one published frame per {@code delayFrame}
+   * beat. Callers should treat {@code delayFrame} like {@code delay} (no credit drain).
+   */
+  public boolean batchBeats() {
+    if (!active || frameBeats <= 0 || sliderTargetSec <= 0f) {
+      return false;
+    }
+    return sliderTargetSec < AppConfig.equalizeFrameFloorSec(frameBeats);
+  }
+
+  /**
+   * After a real {@code delayFrame} beat (non-batching), how many additional published frames to
+   * wait so stretched runs hit {@link #sliderTargetSec()}.
+   */
+  public int takeExtraFrameWaits() {
+    if (!active || batchBeats() || frameBeats <= 0 || sliderTargetSec <= 0f) {
+      return 0;
+    }
+    double idealFramesPerBeat =
+        (sliderTargetSec * (double) AppConfig.TARGET_FRAME_RATE) / (double) frameBeats;
+    frameWaitDebt += Math.max(0d, idealFramesPerBeat - 1d);
+    int extra = (int) frameWaitDebt;
+    frameWaitDebt -= extra;
+    return Math.max(0, extra);
+  }
+
+  /** Arms pacing for one algorithm run. No-op when {@code totalSteps <= 0}. */
+  public void begin(int totalSteps, int frameBeats, float sliderTargetSec) {
+    begin(totalSteps, frameBeats, sliderTargetSec, 0);
+  }
+
+  /**
+   * @param arrayLength used to cap batched {@code delayFrame} beats per draw frame on large arrays
+   */
+  public void begin(int totalSteps, int frameBeats, float sliderTargetSec, int arrayLength) {
+    if (totalSteps <= 0) {
+      clear();
+      return;
+    }
+    this.totalSteps = totalSteps;
+    this.frameBeats = Math.max(0, frameBeats);
+    this.sliderTargetSec = Math.max(0f, sliderTargetSec);
+    this.maxStepsPerFrame =
+        this.frameBeats > 0
+            ? AppConfig.equalizeMaxFrameBeatsPerFrame(arrayLength)
+            : AppConfig.EQUALIZE_MAX_STEPS_PER_FRAME;
+    this.stepsConsumed.set(0);
+    this.frameBeatsConsumed.set(0);
+    this.frameWaitDebt = 0d;
+    this.startNanos = System.nanoTime();
+    this.active = true;
+  }
+
+  public void clear() {
+    active = false;
+    totalSteps = 0;
+    frameBeats = 0;
+    sliderTargetSec = 0f;
+    maxStepsPerFrame = AppConfig.EQUALIZE_MAX_STEPS_PER_FRAME;
+    stepsConsumed.set(0);
+    frameBeatsConsumed.set(0);
+    frameWaitDebt = 0d;
+    startNanos = 0L;
+  }
+
+  public void recordStep() {
+    if (active) {
+      stepsConsumed.incrementAndGet();
+    }
+  }
+
+  public void recordFrameBeat() {
+    if (active) {
+      stepsConsumed.incrementAndGet();
+      frameBeatsConsumed.incrementAndGet();
+    }
+  }
+
+  /**
+   * Credits to grant this frame under schedule correction. Returns {@code -1} when inactive so the
+   * caller can fall back to the speed slider.
+   */
+  public int stepsForDelta(float deltaSeconds) {
+    if (!active || totalSteps <= 0) {
+      return -1;
+    }
+    int remainingSteps = Math.max(0, totalSteps - stepsConsumed.get());
+    if (remainingSteps == 0) {
+      return 1;
+    }
+    float elapsedSec = (System.nanoTime() - startNanos) / 1_000_000_000f;
+    float remainingTime = Math.max(MIN_REMAINING_SEC, sliderTargetSec - elapsedSec);
+
+    if (!batchBeats()) {
+      // Non-batched frame beats still need ~1 credit per published frame; do not try to "catch up"
+      // past that with huge grants (leftover credits are drained by delayFrame).
+      int remainingFrameBeats = Math.max(0, frameBeats - frameBeatsConsumed.get());
+      float frameFloorRemaining = AppConfig.equalizeFrameFloorSec(remainingFrameBeats);
+      remainingTime = Math.max(remainingTime, frameFloorRemaining);
+    }
+
+    int grant = AppConfig.equalizedSortStepsForDelta(deltaSeconds, remainingSteps, remainingTime);
+    return Math.min(grant, maxStepsPerFrame);
+  }
+}

--- a/src/main/java/io/github/compilerstuck/control/model/SortingSessionManager.java
+++ b/src/main/java/io/github/compilerstuck/control/model/SortingSessionManager.java
@@ -1,7 +1,12 @@
 package io.github.compilerstuck.control.model;
 
 import io.github.compilerstuck.control.config.AppConfig;
+import io.github.compilerstuck.control.render.CountingDelayContext;
+import io.github.compilerstuck.control.render.DelayContext;
+import io.github.compilerstuck.control.render.TrackingDelayContext;
 import io.github.compilerstuck.control.ui.TimeEstimateFormat;
+import io.github.compilerstuck.sortingalgorithms.BogoSort;
+import io.github.compilerstuck.sortingalgorithms.GravitySort;
 import io.github.compilerstuck.sortingalgorithms.SortingAlgorithm;
 import io.github.compilerstuck.sound.Sound;
 import java.io.IOException;
@@ -10,7 +15,12 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import java.util.function.DoubleSupplier;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -37,6 +47,10 @@ public class SortingSessionManager {
   private Thread executionThread;
   private volatile CancellationToken cancellationToken = CancellationToken.alwaysActive();
   private volatile FrameGate frameGate;
+
+  private BooleanSupplier equalizeEnabled = () -> false;
+  private DoubleSupplier equalizeTargetSec = () -> 10.0;
+  private Supplier<DelayContext> productionDelayContext = () -> null;
 
   public SortingSessionManager(
       ArrayController arrayController, Sound sound, SortingStateManager stateManager) {
@@ -67,6 +81,19 @@ public class SortingSessionManager {
    */
   public void setFrameGate(FrameGate frameGate) {
     this.frameGate = frameGate;
+  }
+
+  /**
+   * Optional equalize-sort-duration support. {@code productionDelay} supplies the live FrameGate
+   * context (may be null in unit tests).
+   */
+  public void setEqualizeSupport(
+      BooleanSupplier enabled,
+      DoubleSupplier targetDurationSec,
+      Supplier<DelayContext> productionDelay) {
+    this.equalizeEnabled = enabled != null ? enabled : () -> false;
+    this.equalizeTargetSec = targetDurationSec != null ? targetDurationSec : () -> 10.0;
+    this.productionDelayContext = productionDelay != null ? productionDelay : () -> null;
   }
 
   /**
@@ -146,6 +173,7 @@ public class SortingSessionManager {
       stateManager.setRestart(true);
     } finally {
       stateManager.setFrameGateSuspended(false);
+      stateManager.equalizePacing().clear();
       // Drop unused step credits so the render thread cannot deadlock in awaitIdle().
       FrameGate gate = frameGate;
       if (gate != null) {
@@ -183,12 +211,169 @@ public class SortingSessionManager {
   }
 
   private void executeAlgorithm(SortingAlgorithm algorithm) {
-    algorithm.beginTiming();
+    DelayContext production = productionDelayContext.get();
+    DelayContext fallback =
+        production != null
+            ? production
+            : () -> {
+              /* no-op */
+            };
     try {
-      algorithm.sort();
+      if (tryArmEqualizePacing(algorithm, fallback)) {
+        algorithm.setDelayContext(
+            new TrackingDelayContext(fallback, stateManager.equalizePacing()));
+      } else {
+        if (algorithm instanceof GravitySort gravity) {
+          gravity.setColumnStride(1);
+        }
+        algorithm.setDelayContext(fallback);
+      }
+
+      algorithm.beginTiming();
+      try {
+        algorithm.sort();
+      } finally {
+        algorithm.endTiming();
+      }
+    } finally {
+      stateManager.equalizePacing().clear();
+      if (algorithm instanceof GravitySort gravity) {
+        gravity.setColumnStride(1);
+      }
+      algorithm.setDelayContext(fallback);
+    }
+  }
+
+  /**
+   * Silent dry-run that counts visual steps, restores the array, and arms {@link EqualizePacing}.
+   *
+   * @return true when equalize pacing was armed for the visual pass
+   */
+  boolean tryArmEqualizePacing(SortingAlgorithm algorithm, DelayContext production) {
+    if (!equalizeEnabled.getAsBoolean()) {
+      return false;
+    }
+    if (algorithm instanceof BogoSort) {
+      LOGGER.log(Level.INFO, "Equalize skipped for Bogo Sort (unbounded)");
+      return false;
+    }
+    if (!stateManager.shouldContinueExecution() || cancellationToken.isCancelled()) {
+      return false;
+    }
+
+    float sliderTarget = (float) equalizeTargetSec.getAsDouble();
+
+    // Gravity's full column walk is O(n·max) CPU — impossible in a few seconds at 100k. Estimate
+    // beats, then raise columnStride so only ~budget samples are visualized/computed.
+    if (algorithm instanceof GravitySort gravity) {
+      int naturalBeats = GravitySort.estimateFrameBeats(arrayController);
+      if (naturalBeats <= 0) {
+        return false;
+      }
+      int n = arrayController.getLength();
+      int maxPerFrame = AppConfig.equalizeMaxFrameBeatsPerFrame(n);
+      int budget =
+          Math.max(
+              1,
+              Math.round(maxPerFrame * AppConfig.TARGET_FRAME_RATE * Math.max(0.1f, sliderTarget)));
+      int stride = Math.max(1, (naturalBeats + budget - 1) / budget);
+      gravity.setColumnStride(stride);
+      int visualBeats = GravitySort.countVisualBeats(naturalBeats, stride);
+      LOGGER.log(
+          Level.INFO,
+          "Gravity equalize stride={0} (naturalBeats={1}, budget={2}, visualBeats={3})",
+          new Object[] {stride, naturalBeats, budget, visualBeats});
+      return armEqualize(algorithm.getName(), visualBeats, visualBeats, sliderTarget);
+    }
+
+    int[] snapshot = Arrays.copyOf(arrayController.getArray(), arrayController.getLength());
+    OperationReporter previousReporter = stateManager::setCurrentOperation;
+    CancellationToken dryToken = new CancellationToken();
+    CancellationToken sessionToken = cancellationToken;
+    CountingDelayContext counter =
+        new CountingDelayContext(
+            System.nanoTime()
+                + TimeUnit.MILLISECONDS.toNanos(AppConfig.EQUALIZE_DRY_RUN_TIMEOUT_MS),
+            sessionToken::isCancelled,
+            dryToken::cancel);
+
+    stateManager.setCurrentOperation("Preparing…");
+    // Render must not grant FrameGate credits during the dry-run (nothing consumes them).
+    stateManager.setFrameGateSuspended(true);
+    FrameGate gate = frameGate;
+    if (gate != null) {
+      gate.drain();
+    }
+
+    algorithm.setDelayContext(counter);
+    algorithm.setOperationReporter(OperationReporter.NOOP);
+    algorithm.setCancellationToken(dryToken);
+
+    try {
+      sound.withMuted(algorithm::sort);
     } finally {
       algorithm.endTiming();
+      algorithm.setCancellationToken(sessionToken);
+      algorithm.setOperationReporter(previousReporter);
+      algorithm.setDelayContext(production);
+      arrayController.restoreContents(snapshot);
+      arrayController.resetMeasurements();
+      if (gate != null) {
+        gate.drain();
+      }
+      stateManager.setFrameGateSuspended(false);
     }
+
+    if (sessionToken.isCancelled() || !stateManager.shouldContinueExecution()) {
+      return false;
+    }
+    if (counter.timedOut()) {
+      LOGGER.log(
+          Level.INFO,
+          "Equalize dry-run timed out for {0}; using normal speed pacing",
+          algorithm.getName());
+      return false;
+    }
+    if (counter.aborted() || dryToken.isCancelled()) {
+      return false;
+    }
+
+    int totalSteps = clampToInt(counter.stepCount());
+    int frameBeats = clampToInt(counter.frameBeatCount());
+    if (totalSteps <= 0) {
+      return false;
+    }
+
+    return armEqualize(algorithm.getName(), totalSteps, frameBeats, sliderTarget);
+  }
+
+  private boolean armEqualize(
+      String algorithmName, int totalSteps, int frameBeats, float sliderTarget) {
+    stateManager
+        .equalizePacing()
+        .begin(totalSteps, frameBeats, sliderTarget, arrayController.getLength());
+    LOGGER.log(
+        Level.INFO,
+        "Equalize armed for {0}: steps={1}, frameBeats={2}, targetSec={3}, batch={4}, maxSteps/frame={5}",
+        new Object[] {
+          algorithmName,
+          totalSteps,
+          frameBeats,
+          sliderTarget,
+          stateManager.equalizePacing().batchBeats(),
+          stateManager.equalizePacing().maxStepsPerFrame()
+        });
+    return true;
+  }
+
+  private static int clampToInt(long value) {
+    if (value > Integer.MAX_VALUE) {
+      return Integer.MAX_VALUE;
+    }
+    if (value < 0) {
+      return 0;
+    }
+    return (int) value;
   }
 
   private void recordMeasurements() {

--- a/src/main/java/io/github/compilerstuck/control/model/SortingStateManager.java
+++ b/src/main/java/io/github/compilerstuck/control/model/SortingStateManager.java
@@ -22,6 +22,8 @@ public class SortingStateManager {
    */
   private final AtomicBoolean frameGateSuspended = new AtomicBoolean(false);
 
+  private final EqualizePacing equalizePacing = new EqualizePacing();
+
   private volatile String currentOperation = "Waiting";
 
   /**
@@ -109,6 +111,11 @@ public class SortingStateManager {
     frameGateSuspended.set(value);
   }
 
+  /** Equalize-sort-duration pacing for the active algorithm (inactive when mode is off). */
+  public EqualizePacing equalizePacing() {
+    return equalizePacing;
+  }
+
   public String getCurrentOperation() {
     return currentOperation;
   }
@@ -125,6 +132,7 @@ public class SortingStateManager {
     shouldRestart.set(false);
     shuffling.set(false);
     frameGateSuspended.set(false);
+    equalizePacing.clear();
     currentOperation = "Waiting";
   }
 }

--- a/src/main/java/io/github/compilerstuck/control/render/CountingDelayContext.java
+++ b/src/main/java/io/github/compilerstuck/control/render/CountingDelayContext.java
@@ -1,0 +1,90 @@
+package io.github.compilerstuck.control.render;
+
+import java.util.function.BooleanSupplier;
+
+/**
+ * Counts {@link #delay()} / {@link #delayFrame()} calls without blocking. Used for equalize-mode
+ * dry-runs. Optionally times out after a wall-clock deadline or an external cancel signal.
+ */
+public final class CountingDelayContext implements DelayContext {
+  private final long deadlineNanos;
+  private final BooleanSupplier externalCancel;
+  private final Runnable onAbort;
+  private long stepCount;
+  private long frameBeatCount;
+  private boolean timedOut;
+  private boolean aborted;
+
+  /** Unlimited counting (no timeout). */
+  public CountingDelayContext() {
+    this(Long.MAX_VALUE, null, null);
+  }
+
+  /**
+   * @param deadlineNanos {@link System#nanoTime()} after which further delays mark timed-out
+   * @param externalCancel optional; when true, aborts counting (e.g. session cancel)
+   * @param onAbort optional callback invoked once when aborting or timing out
+   */
+  public CountingDelayContext(
+      long deadlineNanos, BooleanSupplier externalCancel, Runnable onAbort) {
+    this.deadlineNanos = deadlineNanos;
+    this.externalCancel = externalCancel;
+    this.onAbort = onAbort;
+  }
+
+  @Override
+  public void delay() {
+    if (shouldStop()) {
+      return;
+    }
+    stepCount++;
+  }
+
+  @Override
+  public void delayFrame() {
+    if (shouldStop()) {
+      return;
+    }
+    stepCount++;
+    frameBeatCount++;
+  }
+
+  private boolean shouldStop() {
+    if (timedOut || aborted) {
+      return true;
+    }
+    if (externalCancel != null && externalCancel.getAsBoolean()) {
+      aborted = true;
+      fireAbort();
+      return true;
+    }
+    if (System.nanoTime() >= deadlineNanos) {
+      timedOut = true;
+      fireAbort();
+      return true;
+    }
+    return false;
+  }
+
+  private void fireAbort() {
+    if (onAbort != null) {
+      onAbort.run();
+    }
+  }
+
+  public long stepCount() {
+    return stepCount;
+  }
+
+  public long frameBeatCount() {
+    return frameBeatCount;
+  }
+
+  public boolean timedOut() {
+    return timedOut;
+  }
+
+  public boolean aborted() {
+    return aborted;
+  }
+}

--- a/src/main/java/io/github/compilerstuck/control/render/DelayContext.java
+++ b/src/main/java/io/github/compilerstuck/control/render/DelayContext.java
@@ -10,4 +10,15 @@ package io.github.compilerstuck.control.render;
 public interface DelayContext {
   /** Block until the next frame-gate step is granted. */
   void delay();
+
+  /**
+   * Wait for the next <em>published</em> frame: discard unused step credits so the render thread
+   * can snapshot, then await one new credit. Use for whole-array visual beats (e.g. one Gravity
+   * Sort column) that must not skip frames when steps-per-frame &gt; 1.
+   *
+   * <p>Default matches {@link #delay()} for simple/no-op contexts.
+   */
+  default void delayFrame() {
+    delay();
+  }
 }

--- a/src/main/java/io/github/compilerstuck/control/render/FakeRenderSystem.java
+++ b/src/main/java/io/github/compilerstuck/control/render/FakeRenderSystem.java
@@ -181,6 +181,15 @@ public final class FakeRenderSystem implements RenderSystem {
   }
 
   @Override
+  public float measureTextWidth(String text, float sizePx) {
+    if (text == null || text.isEmpty() || sizePx <= 0f) {
+      return 0f;
+    }
+    // Rough proportional advance for headless layout tests (Liberation Sans ~0.55em).
+    return text.length() * sizePx * 0.55f;
+  }
+
+  @Override
   public void drawTexts(String[] texts, float x, float[] ys, float sizePx, int count) {
     if (texts == null || count <= 0) {
       return;

--- a/src/main/java/io/github/compilerstuck/control/render/FrameGateDelayContext.java
+++ b/src/main/java/io/github/compilerstuck/control/render/FrameGateDelayContext.java
@@ -18,4 +18,12 @@ public final class FrameGateDelayContext implements DelayContext {
       Thread.currentThread().interrupt();
     }
   }
+
+  @Override
+  public void delayFrame() {
+    // Drop leftover credits from this frame's grant so awaitIdle can publish now, then wait for
+    // the next grant (one visible frame per call regardless of steps-per-frame).
+    frameGate.drain();
+    delay();
+  }
 }

--- a/src/main/java/io/github/compilerstuck/control/render/GdxOverlayPass.java
+++ b/src/main/java/io/github/compilerstuck/control/render/GdxOverlayPass.java
@@ -5,6 +5,7 @@ import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.GlyphLayout;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.utils.Disposable;
 import io.github.compilerstuck.control.render.asset.AppAssets;
@@ -27,6 +28,7 @@ final class GdxOverlayPass implements Disposable {
 
   private final GdxRenderSystem host;
   private final AppAssets assets;
+  private final GlyphLayout glyphLayout = new GlyphLayout();
 
   private ImageRepository imageRepository;
   private ImageRemapRenderer imageRemapRenderer;
@@ -73,6 +75,14 @@ final class GdxOverlayPass implements Disposable {
     world2d.endSprites();
     host.pipeline().enterOverlay();
     host.applyOverlayViewport();
+  }
+
+  float measureTextWidth(String text, float sizePx) {
+    if (text == null || text.isEmpty()) {
+      return 0f;
+    }
+    glyphLayout.setText(assets.font(sizePx), text);
+    return glyphLayout.width;
   }
 
   void drawText(String text, float x, float y, float sizePx) {

--- a/src/main/java/io/github/compilerstuck/control/render/GdxRenderSystem.java
+++ b/src/main/java/io/github/compilerstuck/control/render/GdxRenderSystem.java
@@ -141,8 +141,10 @@ public final class GdxRenderSystem implements RenderSystem, Disposable {
     cam3d.viewportWidth = width;
     cam3d.viewportHeight = height;
     cam3d.fieldOfView = 60f;
-    cam3d.near = 0.1f;
-    cam3d.far = Math.max(width, height) * 20f;
+    // Match GdxWorld3DPass eye distance; keep a tight near/far ratio for depth precision.
+    float eyeZ = (height * 0.5f) / (float) Math.tan(Math.toRadians(30));
+    cam3d.near = Math.max(1f, eyeZ * 0.05f);
+    cam3d.far = Math.max(cam3d.near + 1f, eyeZ * 4f);
     world3d.syncEngineScene(width, height);
   }
 
@@ -275,6 +277,11 @@ public final class GdxRenderSystem implements RenderSystem, Disposable {
   @Override
   public void drawText(String text, float x, float y, float sizePx) {
     overlay.drawText(text, x, y, sizePx);
+  }
+
+  @Override
+  public float measureTextWidth(String text, float sizePx) {
+    return overlay.measureTextWidth(text, sizePx);
   }
 
   @Override

--- a/src/main/java/io/github/compilerstuck/control/render/GdxWorld3DPass.java
+++ b/src/main/java/io/github/compilerstuck/control/render/GdxWorld3DPass.java
@@ -67,6 +67,7 @@ final class GdxWorld3DPass implements Disposable {
     }
     host.applyWorld3DViewport();
     Gdx.gl.glEnable(GL20.GL_DEPTH_TEST);
+    Gdx.gl.glDepthFunc(GL20.GL_LEQUAL);
     Gdx.gl.glEnable(GL20.GL_BLEND);
     Gdx.gl.glBlendFunc(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
   }

--- a/src/main/java/io/github/compilerstuck/control/render/HudRenderer.java
+++ b/src/main/java/io/github/compilerstuck/control/render/HudRenderer.java
@@ -28,19 +28,19 @@ public final class HudRenderer {
   private int cachedTextX;
   private int cachedTextSize;
   private int cachedLineHeight;
+  private int cachedWatermarkX;
+  private int cachedWatermarkSize;
   private boolean labelsInitialized;
 
   public void drawWatermark(RenderSystem rs) {
-    int w = rs.getWidth();
-    ensureLayout(w);
+    ensureLayout(rs);
     // Match first metrics line (e.g. "Waiting") so the watermark isn't flush to the top.
-    rs.drawText(Brand.WATERMARK, w - 190, labelYs[0], 25);
+    rs.drawText(Brand.WATERMARK, cachedWatermarkX, labelYs[0], cachedWatermarkSize);
   }
 
   public void drawMeasurements(
       RenderSystem rs, SortingStateManager stateManager, ArrayController arrayController) {
-    int width = rs.getWidth();
-    ensureLayout(width);
+    ensureLayout(rs);
     rebuildLabelsIfDirty(stateManager, arrayController);
     rs.drawTexts(labels, cachedTextX, labelYs, cachedTextSize, LABEL_COUNT);
   }
@@ -59,7 +59,8 @@ public final class HudRenderer {
     return sameKeys(readMetrics(stateManager, arrayController));
   }
 
-  private void ensureLayout(int width) {
+  private void ensureLayout(RenderSystem rs) {
+    int width = rs.getWidth();
     if (width == cachedLayoutWidth) {
       return;
     }
@@ -67,6 +68,10 @@ public final class HudRenderer {
     cachedTextSize = AppConfig.scaleToWidth(AppConfig.TEXT_Y_OFFSET, width);
     cachedTextX = AppConfig.scaleToWidth(AppConfig.TEXT_X_OFFSET, width);
     cachedLineHeight = AppConfig.scaleToWidth(AppConfig.LINE_HEIGHT_OFFSET, width);
+    cachedWatermarkSize = AppConfig.scaleToWidth(AppConfig.WATERMARK_TEXT_SIZE, width);
+    // Pin the trailing glyph to the same inset as left-side metrics (not a fixed text-width guess).
+    float watermarkW = rs.measureTextWidth(Brand.WATERMARK, cachedWatermarkSize);
+    cachedWatermarkX = Math.round(width - watermarkW - cachedTextX);
     for (int i = 0; i < LABEL_COUNT; i++) {
       labelYs[i] = cachedLineHeight * (i + 1);
     }

--- a/src/main/java/io/github/compilerstuck/control/render/InstanceRenderer3D.java
+++ b/src/main/java/io/github/compilerstuck/control/render/InstanceRenderer3D.java
@@ -140,14 +140,36 @@ public final class InstanceRenderer3D implements Disposable {
       next *= 2;
     }
     LOGGER.info("Growing instance buffer " + maxInstances + " → " + next);
-    boxMesh.disableInstancedRendering();
-    quadMesh.disableInstancedRendering();
-    sphereMesh.disableInstancedRendering();
     maxInstances = next;
     instanceFloats = new float[maxInstances * InstanceTransform.FLOATS_PER_INSTANCE];
+    // Replacing InstanceData on an existing Mesh leaves the VAO stale; next bind aborts in
+    // glVertexAttribDivisor. Dispose + rebuild (same pattern as LineRenderer3D).
+    rebuildMeshes();
+  }
+
+  private void rebuildMeshes() {
+    disposeMeshes();
+    boxMesh = buildBox();
+    quadMesh = buildQuad();
+    sphereMesh = buildSphere();
     enableInstancing(boxMesh);
     enableInstancing(quadMesh);
     enableInstancing(sphereMesh);
+  }
+
+  private void disposeMeshes() {
+    if (boxMesh != null) {
+      boxMesh.dispose();
+      boxMesh = null;
+    }
+    if (quadMesh != null) {
+      quadMesh.dispose();
+      quadMesh = null;
+    }
+    if (sphereMesh != null) {
+      sphereMesh.dispose();
+      sphereMesh = null;
+    }
   }
 
   private void enableInstancing(Mesh mesh) {
@@ -197,18 +219,7 @@ public final class InstanceRenderer3D implements Disposable {
 
   @Override
   public void dispose() {
-    if (boxMesh != null) {
-      boxMesh.dispose();
-      boxMesh = null;
-    }
-    if (quadMesh != null) {
-      quadMesh.dispose();
-      quadMesh = null;
-    }
-    if (sphereMesh != null) {
-      sphereMesh.dispose();
-      sphereMesh = null;
-    }
+    disposeMeshes();
     if (shader != null) {
       shader.dispose();
     }

--- a/src/main/java/io/github/compilerstuck/control/render/PerfOverlay.java
+++ b/src/main/java/io/github/compilerstuck/control/render/PerfOverlay.java
@@ -1,10 +1,9 @@
 package io.github.compilerstuck.control.render;
 
+import io.github.compilerstuck.control.config.AppConfig;
+
 /** Screen-space debug overlay for {@link FrameStats} (enabled via {@code --perf-stats}). */
 public final class PerfOverlay {
-  private static final float TEXT_SIZE = 16f;
-  private static final float LINE = 18f;
-  private static final float MARGIN_X = 8f;
 
   public void draw(RenderSystem rs, FrameStats stats) {
     draw(rs, stats, null);
@@ -14,50 +13,57 @@ public final class PerfOverlay {
     if (rs == null || stats == null) {
       return;
     }
-    int h = rs.getHeight();
-    float y = h - 8f - LINE;
-    int line = 0;
+    Layout layout = Layout.forWidth(rs.getWidth(), rs.getHeight());
 
-    line = text(rs, "fps " + stats.fps, y, line);
-    line =
-        text(
-            rs,
-            String.format(
-                "frame %.2f ms  avg %.2f  1%%low %.0f fps",
-                stats.frameMs, stats.avgFrameMs, stats.onePercentLowFps),
-            y,
-            line);
-    line =
-        text(rs, String.format("heap %.1f / %.1f MB", stats.heapUsedMb, stats.heapMaxMb), y, line);
+    layout.line(rs, "fps " + stats.fps);
+    layout.line(
+        rs,
+        String.format(
+            "frame %.2f ms  avg %.2f  1%%low %.0f fps",
+            stats.frameMs, stats.avgFrameMs, stats.onePercentLowFps));
+    layout.line(rs, String.format("heap %.1f / %.1f MB", stats.heapUsedMb, stats.heapMaxMb));
 
     if (ctx != null) {
-      line = text(rs, ctx.width + "x" + ctx.height + "  N=" + ctx.arrayLength, y, line);
+      layout.line(rs, ctx.width + "x" + ctx.height + "  N=" + ctx.arrayLength);
       String viz =
           ctx.visualization == null || ctx.visualization.isEmpty() ? "?" : ctx.visualization;
-      line =
-          text(
-              rs,
-              viz + "  " + (ctx.running ? "running" : "idle") + "  steps " + ctx.stepsPerFrame,
-              y,
-              line);
-      line = text(rs, "path 3d=instanced  2d=geo", y, line);
+      layout.line(
+          rs, viz + "  " + (ctx.running ? "running" : "idle") + "  steps " + ctx.stepsPerFrame);
+      layout.line(rs, "path 3d=instanced  2d=geo");
     }
 
-    line = text(rs, "texts " + stats.textDraws + "  pixels " + stats.pixelUploads, y, line);
-    line =
-        text(
-            rs,
-            "spriteCalls " + stats.spriteRenderCalls + " (ends " + stats.spriteEnds + ")",
-            y,
-            line);
-    line = text(rs, "instanced " + stats.instancedDraws, y, line);
-    line = text(rs, "instances " + stats.instancesSubmitted, y, line);
-    line = text(rs, "lineDraws " + stats.lineDraws, y, line);
-    text(rs, "geo2d " + stats.geo2dDraws + " prims " + stats.geo2dPrimitives, y, line);
+    layout.line(rs, "texts " + stats.textDraws + "  pixels " + stats.pixelUploads);
+    layout.line(rs, "spriteCalls " + stats.spriteRenderCalls + " (ends " + stats.spriteEnds + ")");
+    layout.line(rs, "instanced " + stats.instancedDraws);
+    layout.line(rs, "instances " + stats.instancesSubmitted);
+    layout.line(rs, "lineDraws " + stats.lineDraws);
+    layout.line(rs, "geo2d " + stats.geo2dDraws + " prims " + stats.geo2dPrimitives);
   }
 
-  private static int text(RenderSystem rs, String s, float y0, int line) {
-    rs.drawText(s, MARGIN_X, y0 - line * LINE, TEXT_SIZE);
-    return line + 1;
+  private static final class Layout {
+    private final float x;
+    private final float y0;
+    private final float lineH;
+    private final float textSize;
+    private int line;
+
+    private Layout(float x, float y0, float lineH, float textSize) {
+      this.x = x;
+      this.y0 = y0;
+      this.lineH = lineH;
+      this.textSize = textSize;
+    }
+
+    static Layout forWidth(int width, int height) {
+      float textSize = AppConfig.scaleToWidth(AppConfig.PERF_TEXT_SIZE, width);
+      float lineH = AppConfig.scaleToWidth(AppConfig.PERF_LINE_HEIGHT, width);
+      float margin = AppConfig.scaleToWidth(AppConfig.PERF_MARGIN, width);
+      return new Layout(margin, height - margin - lineH, lineH, textSize);
+    }
+
+    void line(RenderSystem rs, String s) {
+      rs.drawText(s, x, y0 - line * lineH, textSize);
+      line++;
+    }
   }
 }

--- a/src/main/java/io/github/compilerstuck/control/render/RenderSystem.java
+++ b/src/main/java/io/github/compilerstuck/control/render/RenderSystem.java
@@ -63,6 +63,14 @@ public interface RenderSystem {
   void drawText(String text, float x, float y, float sizePx);
 
   /**
+   * Overlay: advance width of {@code text} at {@code sizePx}. Returns {@code 0} when unknown (e.g.
+   * null/empty text).
+   */
+  default float measureTextWidth(String text, float sizePx) {
+    return 0f;
+  }
+
+  /**
    * Overlay: draw multiple strings in one SpriteBatch session. {@code ys[i]} is top-left Y (same
    * convention as {@link #drawText}).
    */

--- a/src/main/java/io/github/compilerstuck/control/render/TrackingDelayContext.java
+++ b/src/main/java/io/github/compilerstuck/control/render/TrackingDelayContext.java
@@ -1,0 +1,43 @@
+package io.github.compilerstuck.control.render;
+
+import io.github.compilerstuck.control.model.EqualizePacing;
+import java.util.Objects;
+
+/**
+ * Delegates to a production {@link DelayContext} while recording consumed equalize steps.
+ *
+ * <p>For {@link #delayFrame()}, applies equalize policy: batch beats into plain {@link #delay()}
+ * calls when the target is below the one-frame-per-beat floor, or insert extra published frames
+ * when stretching longer than that floor.
+ */
+public final class TrackingDelayContext implements DelayContext {
+  private final DelayContext delegate;
+  private final EqualizePacing pacing;
+
+  public TrackingDelayContext(DelayContext delegate, EqualizePacing pacing) {
+    this.delegate = Objects.requireNonNull(delegate, "delegate");
+    this.pacing = Objects.requireNonNull(pacing, "pacing");
+  }
+
+  @Override
+  public void delay() {
+    pacing.recordStep();
+    delegate.delay();
+  }
+
+  @Override
+  public void delayFrame() {
+    pacing.recordFrameBeat();
+    if (pacing.batchBeats()) {
+      // Hit short targets: allow multiple columns per published frame (no drain).
+      delegate.delay();
+      return;
+    }
+    delegate.delayFrame();
+    int extra = pacing.takeExtraFrameWaits();
+    for (int i = 0; i < extra; i++) {
+      // Empty published frames between beats (still drain+await).
+      delegate.delayFrame();
+    }
+  }
+}

--- a/src/main/java/io/github/compilerstuck/control/screen/VisualizerScreen.java
+++ b/src/main/java/io/github/compilerstuck/control/screen/VisualizerScreen.java
@@ -147,10 +147,13 @@ public final class VisualizerScreen implements Screen {
       game.appContext().publishArraySnapshot();
     }
     if (game.appContext() != null) {
-      int steps =
-          game.stateManager().isShuffling()
-              ? AppConfig.shuffleStepsForDelta(delta)
-              : game.appContext().getStepsPerFrame();
+      int steps;
+      if (game.stateManager().isShuffling()) {
+        steps = AppConfig.shuffleStepsForDelta(delta);
+      } else {
+        int equalized = game.stateManager().equalizePacing().stepsForDelta(delta);
+        steps = equalized >= 0 ? equalized : game.appContext().getStepsPerFrame();
+      }
       game.appContext().getFrameGate().grant(steps);
     }
     game.drawWorld(delta);

--- a/src/main/java/io/github/compilerstuck/control/ui/ResultsTableRenderer.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/ResultsTableRenderer.java
@@ -28,14 +28,18 @@ public final class ResultsTableRenderer {
     rs.clear(bg, bg, bg);
 
     float textSize = AppConfig.scaleToWidth(AppConfig.FONT_SIZE_RATIO, width);
+    float topRow = AppConfig.scaleToWidth(AppConfig.TABLE_TOP_ROW, width);
+    float cellPad = AppConfig.scaleToWidth(AppConfig.TABLE_CELL_PADDING, width);
 
     drawGrid(rs, width, height);
-    drawHeaders(rs, width, textSize);
+    drawHeaders(rs, width, textSize, cellPad);
     drawData(
         rs,
         width,
         height,
         textSize,
+        topRow,
+        cellPad,
         algorithms,
         comparisons,
         realTime,
@@ -73,17 +77,18 @@ public final class ResultsTableRenderer {
     rs.strokeLines(gridLines, gridArgb, count);
   }
 
-  private void drawHeaders(RenderSystem rs, int width, float textSize) {
+  private void drawHeaders(RenderSystem rs, int width, float textSize, float cellPad) {
     float columnWidth = width * AppConfig.TABLE_COLUMN_WIDTH_RATIO;
     float textY = textSize;
+    float halfPad = cellPad * 0.5f;
 
-    rs.drawText("Alg. name", columnWidth * 0 + 10, textY, textSize);
-    rs.drawText("Elements", columnWidth * 1 + columnWidth / 2 + 5, textY, textSize);
-    rs.drawText("Comparisons", columnWidth * 2 + 10, textY, textSize);
-    rs.drawText("Est. real time", columnWidth * 3 + 10, textY, textSize);
-    rs.drawText("Swaps", columnWidth * 4 + 10, textY, textSize);
-    rs.drawText("Writes main", columnWidth * 5 + 10, textY, textSize);
-    rs.drawText("Writes aux", columnWidth * 6 + 10, textY, textSize);
+    rs.drawText("Alg. name", columnWidth * 0 + cellPad, textY, textSize);
+    rs.drawText("Elements", columnWidth * 1 + columnWidth / 2 + halfPad, textY, textSize);
+    rs.drawText("Comparisons", columnWidth * 2 + cellPad, textY, textSize);
+    rs.drawText("Est. real time", columnWidth * 3 + cellPad, textY, textSize);
+    rs.drawText("Swaps", columnWidth * 4 + cellPad, textY, textSize);
+    rs.drawText("Writes main", columnWidth * 5 + cellPad, textY, textSize);
+    rs.drawText("Writes aux", columnWidth * 6 + cellPad, textY, textSize);
   }
 
   private void drawData(
@@ -91,6 +96,8 @@ public final class ResultsTableRenderer {
       int width,
       int height,
       float textSize,
+      float topRow,
+      float cellPad,
       List<SortingAlgorithm> algorithms,
       List<String> comparisons,
       List<String> realTime,
@@ -102,7 +109,7 @@ public final class ResultsTableRenderer {
     }
 
     float columnWidth = width * AppConfig.TABLE_COLUMN_WIDTH_RATIO;
-    float rowHeight = (height - AppConfig.TABLE_TOP_ROW) / algorithms.size();
+    float rowHeight = (height - topRow) / algorithms.size();
     int textColor = packGray(AppConfig.RESULTS_TABLE_TEXT_COLOR);
 
     if (rowLines == null || rowLines.length < algorithms.size() * 4) {
@@ -111,7 +118,7 @@ public final class ResultsTableRenderer {
     }
 
     for (int i = 0; i < algorithms.size(); i++) {
-      float rowY = AppConfig.TABLE_TOP_ROW + rowHeight * i;
+      float rowY = topRow + rowHeight * i;
       int o = i * 4;
       rowLines[o] = 0;
       rowLines[o + 1] = rowY;
@@ -123,6 +130,8 @@ public final class ResultsTableRenderer {
           rs,
           height,
           textSize,
+          topRow,
+          cellPad,
           i,
           columnWidth,
           rowY,
@@ -140,6 +149,8 @@ public final class ResultsTableRenderer {
       RenderSystem rs,
       int height,
       float textSize,
+      float topRow,
+      float cellPad,
       int index,
       float columnWidth,
       float rowY,
@@ -150,19 +161,19 @@ public final class ResultsTableRenderer {
       List<String> writesMain,
       List<String> writesAux) {
     SortingAlgorithm alg = algorithms.get(index);
-    float rowCenterY = rowY + 10 + (height - AppConfig.TABLE_TOP_ROW) / algorithms.size() / 2;
+    float rowCenterY = rowY + cellPad + (height - topRow) / algorithms.size() / 2;
 
-    rs.drawText(alg.getName(), columnWidth * 0 + 10, rowCenterY, textSize);
+    rs.drawText(alg.getName(), columnWidth * 0 + cellPad, rowCenterY, textSize);
     rs.drawText(
         String.valueOf(alg.getAlternativeSize()),
-        (int) (columnWidth * 1 + columnWidth / 2) + 10,
+        columnWidth * 1 + columnWidth / 2 + cellPad,
         rowCenterY,
         textSize);
 
     if (index < comparisons.size()) {
       rs.drawText(
           String.format("%,d", Long.parseLong(comparisons.get(index))),
-          (int) (columnWidth * 2) + 10,
+          columnWidth * 2 + cellPad,
           rowCenterY,
           textSize);
     }
@@ -170,13 +181,13 @@ public final class ResultsTableRenderer {
     if (index < realTime.size()) {
       String timeStr =
           "~" + TimeEstimateFormat.format(Double.parseDouble(realTime.get(index))) + "ms";
-      rs.drawText(timeStr, (int) (columnWidth * 3) + 10, rowCenterY, textSize);
+      rs.drawText(timeStr, columnWidth * 3 + cellPad, rowCenterY, textSize);
     }
 
     if (index < swaps.size()) {
       rs.drawText(
           String.format("%,d", Long.parseLong(swaps.get(index))),
-          (int) (columnWidth * 4) + 10,
+          columnWidth * 4 + cellPad,
           rowCenterY,
           textSize);
     }
@@ -184,7 +195,7 @@ public final class ResultsTableRenderer {
     if (index < writesMain.size()) {
       rs.drawText(
           String.format("%,d", Long.parseLong(writesMain.get(index))),
-          (int) (columnWidth * 5) + 10,
+          columnWidth * 5 + cellPad,
           rowCenterY,
           textSize);
     }
@@ -192,7 +203,7 @@ public final class ResultsTableRenderer {
     if (index < writesAux.size()) {
       rs.drawText(
           String.format("%,d", Long.parseLong(writesAux.get(index))),
-          (int) (columnWidth * 6) + 10,
+          columnWidth * 6 + cellPad,
           rowCenterY,
           textSize);
     }

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/DebugSection.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/DebugSection.java
@@ -3,6 +3,7 @@ package io.github.compilerstuck.control.ui.settingsfx;
 import io.github.compilerstuck.control.ui.settingsfx.vm.DebugViewModel;
 import javafx.scene.Node;
 import javafx.scene.control.CheckBox;
+import javafx.scene.control.Tooltip;
 
 /** Debug toggles bound to {@link DebugViewModel}. */
 public final class DebugSection {
@@ -14,6 +15,7 @@ public final class DebugSection {
   public static Node build(DebugViewModel vm) {
     CheckBox perfStats = new CheckBox(SettingsStrings.SHOW_PERF_STATS);
     perfStats.setId(ROOT_ID);
+    perfStats.setTooltip(new Tooltip(SettingsStrings.SHOW_PERF_STATS_TOOLTIP));
     perfStats.setSelected(vm.isPerfStats());
     perfStats
         .selectedProperty()

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/OptionsSection.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/OptionsSection.java
@@ -5,6 +5,7 @@ import io.github.compilerstuck.control.ui.settingsfx.vm.DisplayViewModel;
 import io.github.compilerstuck.control.ui.settingsfx.vm.SoundViewModel;
 import javafx.scene.Node;
 import javafx.scene.control.CheckBox;
+import javafx.scene.control.Tooltip;
 import javafx.scene.layout.VBox;
 
 /**
@@ -22,6 +23,7 @@ public final class OptionsSection {
   public static Node build(
       DisplayViewModel displayVm, SoundViewModel soundVm, DebugViewModel debugVm) {
     CheckBox measurements = new CheckBox(SettingsStrings.SHOW_MEASUREMENTS);
+    measurements.setTooltip(new Tooltip(SettingsStrings.SHOW_MEASUREMENTS_TOOLTIP));
     measurements.setSelected(displayVm.isPrintMeasurements());
     measurements
         .selectedProperty()
@@ -33,6 +35,7 @@ public final class OptionsSection {
             });
 
     CheckBox comparison = new CheckBox(SettingsStrings.SHOW_COMPARISON_TABLE);
+    comparison.setTooltip(new Tooltip(SettingsStrings.SHOW_COMPARISON_TABLE_TOOLTIP));
     comparison.setSelected(displayVm.isShowComparisonTable());
     comparison
         .selectedProperty()
@@ -44,6 +47,7 @@ public final class OptionsSection {
             });
 
     CheckBox startDelay = new CheckBox(SettingsStrings.FIVE_SECOND_START_DELAY);
+    startDelay.setTooltip(new Tooltip(SettingsStrings.FIVE_SECOND_START_DELAY_TOOLTIP));
     startDelay.setSelected(displayVm.isFiveSecondStartDelay());
     startDelay
         .selectedProperty()
@@ -105,7 +109,12 @@ public final class OptionsSection {
         displayVm::addPropertyChangeListener,
         DisplayViewModel.PROP_INPUTS_ENABLED);
 
-    VBox root = new VBox(SettingsLayout.GAP_SM, display, sound, debug);
+    VBox root =
+        new VBox(
+            SettingsLayout.GAP_MD,
+            SettingsControls.optionGroup(SettingsStrings.OPTIONS_GROUP_DISPLAY, display),
+            SettingsControls.optionGroup(SettingsStrings.OPTIONS_GROUP_AUDIO, sound),
+            SettingsControls.optionGroup(SettingsStrings.OPTIONS_GROUP_DEBUG, debug));
     root.setId(ROOT_ID);
     return root;
   }

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/OptionsSection.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/OptionsSection.java
@@ -10,7 +10,8 @@ import javafx.scene.layout.VBox;
 /**
  * Combined Options section: display toggles, sound, and debug.
  *
- * <p>Keeps both Settings columns at three sections so heights stay balanced.
+ * <p>Keeps both Settings columns at three sections so heights stay balanced. Equalize-sort-duration
+ * lives in {@link SpeedSection} next to the dial it remaps.
  */
 public final class OptionsSection {
 

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SettingsControls.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SettingsControls.java
@@ -38,6 +38,15 @@ public final class SettingsControls {
     return label;
   }
 
+  /** Muted micro-header + content for Options subgroups (Display / Audio / Debug). */
+  public static VBox optionGroup(String title, Node content) {
+    Label label = new Label(title);
+    label.getStyleClass().add("settings-option-group-label");
+    VBox group = new VBox(SettingsLayout.GAP_XS, label, content);
+    group.setFillWidth(true);
+    return group;
+  }
+
   /** Field label left, live value right - used above sliders. */
   public static HBox labelValueHeader(String fieldText, Label value) {
     Region spacer = new Region();

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SettingsFxController.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SettingsFxController.java
@@ -233,7 +233,7 @@ public final class SettingsFxController implements SettingsBridge {
             new SectionNodes(
                 ArraySizeSection.build(arraySizeVm),
                 SortingSection.build(algorithmVm),
-                SpeedSection.build(speedVm),
+                SpeedSection.build(speedVm, displayVm),
                 VisualizationSection.build(visualizationVm),
                 AppearanceSection.build(appearanceVm),
                 OptionsSection.build(displayVm, soundVm, debugVm)));

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SettingsShell.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SettingsShell.java
@@ -1,6 +1,8 @@
 package io.github.compilerstuck.control.ui.settingsfx;
 
 import atlantafx.base.theme.Styles;
+import io.github.compilerstuck.control.config.AppConfig;
+import javafx.geometry.Bounds;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
@@ -11,6 +13,7 @@ import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
+import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 
 /**
@@ -92,18 +95,60 @@ public final class SettingsShell {
             section(SettingsStrings.SECTION_APPEARANCE, sections.appearance()),
             section(SettingsStrings.SECTION_OPTIONS, sections.options()));
 
-    HBox columns = new HBox(SettingsLayout.GAP_COL, left, right);
-    columns.setAlignment(Pos.TOP_LEFT);
+    HBox sideBySide = new HBox(SettingsLayout.GAP_COL);
+    sideBySide.setAlignment(Pos.TOP_LEFT);
     HBox.setHgrow(left, Priority.ALWAYS);
     HBox.setHgrow(right, Priority.ALWAYS);
     left.setMaxWidth(Double.MAX_VALUE);
     right.setMaxWidth(Double.MAX_VALUE);
+    sideBySide.getChildren().setAll(left, right);
 
-    ScrollPane scroll = new ScrollPane(columns);
+    VBox stacked = new VBox(SettingsLayout.GAP_XL);
+    stacked.setFillWidth(true);
+    stacked.setAlignment(Pos.TOP_LEFT);
+
+    StackPane host = new StackPane(sideBySide);
+    host.setMaxWidth(Double.MAX_VALUE);
+    StackPane.setAlignment(sideBySide, Pos.TOP_LEFT);
+
+    ScrollPane scroll = new ScrollPane(host);
     scroll.setFitToWidth(true);
     scroll.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
     scroll.setFocusTraversable(false);
+
+    scroll
+        .viewportBoundsProperty()
+        .addListener(
+            (obs, oldBounds, bounds) ->
+                applyColumnLayout(host, sideBySide, stacked, left, right, bounds));
+    applyColumnLayout(host, sideBySide, stacked, left, right, scroll.getViewportBounds());
+
     return scroll;
+  }
+
+  private static void applyColumnLayout(
+      StackPane host, HBox sideBySide, VBox stacked, VBox left, VBox right, Bounds viewport) {
+    double width = viewport == null ? 0 : viewport.getWidth();
+    boolean shouldStack = width > 0 && width < AppConfig.SETTINGS_STACK_BREAKPOINT;
+    boolean isStacked = !host.getChildren().isEmpty() && host.getChildren().getFirst() == stacked;
+    if (width <= 0) {
+      return;
+    }
+    if (shouldStack == isStacked
+        && (!sideBySide.getChildren().isEmpty() || !stacked.getChildren().isEmpty())) {
+      return;
+    }
+    if (shouldStack) {
+      sideBySide.getChildren().clear();
+      stacked.getChildren().setAll(left, right);
+      host.getChildren().setAll(stacked);
+      StackPane.setAlignment(stacked, Pos.TOP_LEFT);
+    } else {
+      stacked.getChildren().clear();
+      sideBySide.getChildren().setAll(left, right);
+      host.getChildren().setAll(sideBySide);
+      StackPane.setAlignment(sideBySide, Pos.TOP_LEFT);
+    }
   }
 
   private static VBox column(Node... sectionNodes) {

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SettingsStrings.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SettingsStrings.java
@@ -101,6 +101,7 @@ public final class SettingsStrings {
   public static final String SHUFFLE = "Shuffle";
   public static final String SWATCH_HINT = "Click a swatch to edit";
   public static final String SPEED_SLOW = "Very Slow";
+  public static final String SPEED_DEFAULT = "Default";
   public static final String SPEED_FAST = "Max Fast";
   public static final String IMAGE_PATH_PROMPT = "Image path";
 

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SettingsStrings.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SettingsStrings.java
@@ -5,7 +5,7 @@ public final class SettingsStrings {
 
   public static final String WINDOW_TITLE = "Sorting Algorithm Visualizer - Settings";
   public static final String TITLE = "Settings";
-  public static final String LOADING = "Loading..";
+  public static final String LOADING = "Loading…";
 
   public static final String SECTION_ARRAY_SIZE = "ARRAY SIZE";
   public static final String SECTION_SORTING = "SORTING";
@@ -14,19 +14,22 @@ public final class SettingsStrings {
   public static final String SECTION_APPEARANCE = "APPEARANCE";
   public static final String SECTION_OPTIONS = "OPTIONS";
 
+  public static final String OPTIONS_GROUP_DISPLAY = "Display";
+  public static final String OPTIONS_GROUP_AUDIO = "Audio";
+  public static final String OPTIONS_GROUP_DEBUG = "Debug";
+
   public static final String ALGORITHM = "Algorithm";
   public static final String SIZE = "Size";
   public static final String ARRAY_SIZE_FPS_WARNING =
       "Preview is below 24 FPS at this size.\nSorting will be even heavier, consider fewer elements.";
   public static final String ARRAY_SIZE_HIGH_WARNING =
       "Large array sizes can lag the preview and sorting.\nConsider staying at 20,000 or fewer if performance matters.";
-  public static final String LEVEL = "Level";
+  public static final String ARRAY_SIZE_WHOLE_NUMBER = "Enter a whole number";
   public static final String SPEED_HEADER = "Speed";
   public static final String SPEED_DURATION_HEADER = "Target duration";
   public static final String PRESET = "Preset";
   public static final String IMAGE = "Image";
   public static final String COLORS = "Colors";
-  public static final String SPEED_LEVEL_FORMAT = "%d / %d";
   public static final String SPEED_STEPS_VALUE_FORMAT = "%d steps/frame";
   public static final String SPEED_DURATION_VALUE_FORMAT = "~%d s";
 
@@ -44,6 +47,8 @@ public final class SettingsStrings {
   public static final String RESET_ALL_VISUALS_MESSAGE =
       "Reset every visualization's customization to its defaults? Saved settings will be cleared.";
   public static final String RESET_ALL_VISUALS_CONFIRM = "Reset all";
+  public static final String RESET_ALL_VISUALS_TOOLTIP =
+      "Clear customizations for every visualization.";
   public static final String RESET_ALL_VISUALS_BUSY_TOOLTIP = "Unavailable while sorting.";
   public static final String CONFIGURE_ORDER_UNAVAILABLE_TOOLTIP =
       "Enable Run all to configure the algorithm order.";
@@ -97,14 +102,26 @@ public final class SettingsStrings {
   public static final String CLEAR_SELECTION = "Clear";
   public static final String DRAG_HANDLE = "⠿";
   public static final String RUN_ALL = "Run all";
+  public static final String RUN_ALL_TOOLTIP =
+      "Run the selected algorithms in order instead of a single algorithm.";
   public static final String SOUND_EFFECTS = "Sound effects";
+  public static final String SOUND_EFFECTS_TOOLTIP =
+      "Play pitch cues as the array is accessed during sorting.";
   public static final String SHOW_MEASUREMENTS = "Show measurements";
+  public static final String SHOW_MEASUREMENTS_TOOLTIP =
+      "Show comparison, swap, and write counters on the visualization.";
   public static final String SHOW_COMPARISON_TABLE = "Show comparison table when finished";
+  public static final String SHOW_COMPARISON_TABLE_TOOLTIP =
+      "Overlay a results table after sorting finishes.";
   public static final String FIVE_SECOND_START_DELAY = "5 second start delay";
+  public static final String FIVE_SECOND_START_DELAY_TOOLTIP =
+      "Pause before the shuffle so you can switch to the visualization window.";
   public static final String EQUALIZE_SORT_DURATION = "Equalize sort duration";
   public static final String EQUALIZE_SORT_DURATION_TOOLTIP =
       "Pace each sort to the speed slider's target time. Frame-synced steps (e.g. Gravity Sort) may take longer.";
   public static final String SHOW_PERF_STATS = "Show render performance stats";
+  public static final String SHOW_PERF_STATS_TOOLTIP =
+      "Show FPS and render timing on the visualization (available while sorting).";
   public static final String SHUFFLE = "Shuffle";
   public static final String SWATCH_HINT = "Click a swatch to edit";
   public static final String SPEED_SLOW = "Slow";

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SettingsStrings.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SettingsStrings.java
@@ -21,10 +21,14 @@ public final class SettingsStrings {
   public static final String ARRAY_SIZE_HIGH_WARNING =
       "Large array sizes can lag the preview and sorting.\nConsider staying at 20,000 or fewer if performance matters.";
   public static final String LEVEL = "Level";
+  public static final String SPEED_HEADER = "Speed";
+  public static final String SPEED_DURATION_HEADER = "Target duration";
   public static final String PRESET = "Preset";
   public static final String IMAGE = "Image";
   public static final String COLORS = "Colors";
   public static final String SPEED_LEVEL_FORMAT = "%d / %d";
+  public static final String SPEED_STEPS_VALUE_FORMAT = "%d steps/frame";
+  public static final String SPEED_DURATION_VALUE_FORMAT = "~%d s";
 
   public static final String RUN = "Run";
   public static final String CANCEL = "Cancel";
@@ -95,14 +99,19 @@ public final class SettingsStrings {
   public static final String RUN_ALL = "Run all";
   public static final String SOUND_EFFECTS = "Sound effects";
   public static final String SHOW_MEASUREMENTS = "Show measurements";
-  public static final String SHOW_COMPARISON_TABLE = "Show comparison table";
+  public static final String SHOW_COMPARISON_TABLE = "Show comparison table when finished";
   public static final String FIVE_SECOND_START_DELAY = "5 second start delay";
+  public static final String EQUALIZE_SORT_DURATION = "Equalize sort duration";
+  public static final String EQUALIZE_SORT_DURATION_TOOLTIP =
+      "Pace each sort to the speed slider's target time. Frame-synced steps (e.g. Gravity Sort) may take longer.";
   public static final String SHOW_PERF_STATS = "Show render performance stats";
   public static final String SHUFFLE = "Shuffle";
   public static final String SWATCH_HINT = "Click a swatch to edit";
-  public static final String SPEED_SLOW = "Very Slow";
+  public static final String SPEED_SLOW = "Slow";
   public static final String SPEED_DEFAULT = "Default";
-  public static final String SPEED_FAST = "Max Fast";
+  public static final String SPEED_FAST = "Fast";
+  public static final String SPEED_EQUALIZE_SLOW = "Longer";
+  public static final String SPEED_EQUALIZE_FAST = "Faster";
   public static final String IMAGE_PATH_PROMPT = "Image path";
 
   private SettingsStrings() {}

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SortingSection.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SortingSection.java
@@ -60,6 +60,7 @@ public final class SortingSection {
 
     ToggleSwitch runAll = new ToggleSwitch();
     runAll.setSelected(vm.isRunAll());
+    runAll.setTooltip(new Tooltip(SettingsStrings.RUN_ALL_TOOLTIP));
     runAll
         .selectedProperty()
         .addListener(
@@ -86,11 +87,9 @@ public final class SortingSection {
     HBox.setHgrow(runAllSpacer, Priority.ALWAYS);
     HBox runAllControls = new HBox(SettingsLayout.GAP_SM, runAll, runAllSpacer, configureHost);
     runAllControls.setAlignment(Pos.CENTER_LEFT);
-    VBox runAllField =
-        new VBox(
-            SettingsLayout.GAP_XS,
-            SettingsControls.fieldLabel(SettingsStrings.RUN_ALL),
-            runAllControls);
+    var runAllLabel = SettingsControls.fieldLabel(SettingsStrings.RUN_ALL);
+    runAllLabel.setTooltip(new Tooltip(SettingsStrings.RUN_ALL_TOOLTIP));
+    VBox runAllField = new VBox(SettingsLayout.GAP_XS, runAllLabel, runAllControls);
 
     ComboBox<ShuffleType> shuffle = new ComboBox<>();
     shuffle.getItems().setAll(vm.getShuffleTypes());

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SoundSection.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SoundSection.java
@@ -3,6 +3,7 @@ package io.github.compilerstuck.control.ui.settingsfx;
 import io.github.compilerstuck.control.ui.settingsfx.vm.SoundViewModel;
 import javafx.scene.Node;
 import javafx.scene.control.CheckBox;
+import javafx.scene.control.Tooltip;
 
 /** Sound effects checkbox bound to {@link SoundViewModel}. */
 public final class SoundSection {
@@ -14,6 +15,7 @@ public final class SoundSection {
   public static Node build(SoundViewModel vm) {
     CheckBox soundEffects = new CheckBox(SettingsStrings.SOUND_EFFECTS);
     soundEffects.setId(ROOT_ID);
+    soundEffects.setTooltip(new Tooltip(SettingsStrings.SOUND_EFFECTS_TOOLTIP));
     soundEffects.setSelected(vm.isSoundEnabled());
     soundEffects
         .selectedProperty()

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SpeedSection.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SpeedSection.java
@@ -10,6 +10,7 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
+import javafx.util.StringConverter;
 
 /** Speed level slider with live value (disabled while running, G5). */
 public final class SpeedSection {
@@ -30,7 +31,22 @@ public final class SpeedSection {
     slider.setMinorTickCount(0);
     slider.setSnapToTicks(true);
     slider.setShowTickMarks(true);
-    slider.setShowTickLabels(false);
+    slider.setShowTickLabels(true);
+    slider.setLabelFormatter(
+        new StringConverter<Double>() {
+          @Override
+          public String toString(Double n) {
+            if (n != null && Math.round(n) == SettingsDefaults.DEFAULT_SPEED_LEVEL) {
+              return SettingsStrings.SPEED_DEFAULT;
+            }
+            return "";
+          }
+
+          @Override
+          public Double fromString(String s) {
+            return Double.NaN;
+          }
+        });
     slider
         .valueProperty()
         .addListener(

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SpeedSection.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SpeedSection.java
@@ -1,27 +1,63 @@
 package io.github.compilerstuck.control.ui.settingsfx;
 
 import io.github.compilerstuck.control.config.SettingsDefaults;
+import io.github.compilerstuck.control.ui.settingsfx.vm.DisplayViewModel;
 import io.github.compilerstuck.control.ui.settingsfx.vm.SpeedViewModel;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
+import javafx.scene.control.CheckBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.Slider;
+import javafx.scene.control.Tooltip;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 import javafx.util.StringConverter;
 
-/** Speed level slider with live value (disabled while running, G5). */
+/**
+ * Speed level slider with per-step tick labels. Labels show steps/frame normally, or target sort
+ * duration in seconds when equalize-sort-duration mode is on. The equalize toggle lives here so it
+ * sits next to the control whose meaning it changes.
+ */
 public final class SpeedSection {
 
   public static final String ROOT_ID = "section-speed";
+  public static final String EQUALIZE_ID = "speed-equalize";
 
   private SpeedSection() {}
 
   public static Node build(SpeedViewModel vm) {
+    return build(vm, null);
+  }
+
+  public static Node build(SpeedViewModel vm, DisplayViewModel displayVm) {
+    CheckBox equalize = null;
+    if (displayVm != null) {
+      equalize = new CheckBox(SettingsStrings.EQUALIZE_SORT_DURATION);
+      equalize.setId(EQUALIZE_ID);
+      equalize.setSelected(displayVm.isEqualizeSortDuration());
+      equalize.setTooltip(new Tooltip(SettingsStrings.EQUALIZE_SORT_DURATION_TOOLTIP));
+      equalize
+          .selectedProperty()
+          .addListener(
+              (obs, old, selected) -> {
+                if (selected != displayVm.isEqualizeSortDuration()) {
+                  displayVm.setEqualizeSortDuration(selected);
+                }
+              });
+      VmBindings.bindInputsEnabled(
+          equalize,
+          displayVm::isInputsEnabled,
+          displayVm::addPropertyChangeListener,
+          DisplayViewModel.PROP_INPUTS_ENABLED);
+    }
+
     Label value = SettingsControls.valueLabel();
-    value.setText(formatLevel(vm.getSpeedLevel()));
+    value.setText(formatValue(vm.getSpeedLevel(), equalizeOn(displayVm)));
+
+    HBox header = SettingsControls.labelValueHeader(headerText(equalizeOn(displayVm)), value);
+    Label headerTitle = (Label) header.getChildren().get(0);
 
     Slider slider =
         new Slider(
@@ -32,42 +68,41 @@ public final class SpeedSection {
     slider.setSnapToTicks(true);
     slider.setShowTickMarks(true);
     slider.setShowTickLabels(true);
-    slider.setLabelFormatter(
-        new StringConverter<Double>() {
-          @Override
-          public String toString(Double n) {
-            if (n != null && Math.round(n) == SettingsDefaults.DEFAULT_SPEED_LEVEL) {
-              return SettingsStrings.SPEED_DEFAULT;
-            }
-            return "";
-          }
+    applyTickLabels(slider, equalizeOn(displayVm));
 
-          @Override
-          public Double fromString(String s) {
-            return Double.NaN;
-          }
-        });
     slider
         .valueProperty()
         .addListener(
             (obs, old, v) -> {
               int level = (int) Math.round(v.doubleValue());
-              value.setText(formatLevel(level));
+              value.setText(formatValue(level, equalizeOn(displayVm)));
               if (level != vm.getSpeedLevel()) {
                 vm.setSpeedLevel(level);
               }
             });
 
-    HBox header = SettingsControls.labelValueHeader(SettingsStrings.LEVEL, value);
-
-    Label slow = SettingsControls.mutedLabel(SettingsStrings.SPEED_SLOW);
-    Label fast = SettingsControls.mutedLabel(SettingsStrings.SPEED_FAST);
+    Label slow = SettingsControls.mutedLabel(slowText(equalizeOn(displayVm)));
+    Label fast = SettingsControls.mutedLabel(fastText(equalizeOn(displayVm)));
     Region endpointsSpacer = new Region();
     HBox.setHgrow(endpointsSpacer, Priority.ALWAYS);
     HBox endpoints = new HBox(SettingsLayout.GAP_SM, slow, endpointsSpacer, fast);
     endpoints.setAlignment(Pos.CENTER_LEFT);
 
     VBox sliderBlock = new VBox(SettingsLayout.GAP_XS, slider, endpoints);
+
+    CheckBox equalizeBox = equalize;
+    Runnable refreshLabels =
+        () -> {
+          boolean on = equalizeOn(displayVm);
+          if (equalizeBox != null && equalizeBox.isSelected() != on) {
+            equalizeBox.setSelected(on);
+          }
+          headerTitle.setText(headerText(on));
+          value.setText(formatValue(vm.getSpeedLevel(), on));
+          slow.setText(slowText(on));
+          fast.setText(fastText(on));
+          applyTickLabels(slider, on);
+        };
 
     vm.addPropertyChangeListener(
         evt -> {
@@ -78,10 +113,19 @@ public final class SpeedSection {
                   if ((int) Math.round(slider.getValue()) != level) {
                     slider.setValue(level);
                   }
-                  value.setText(formatLevel(level));
+                  value.setText(formatValue(level, equalizeOn(displayVm)));
                 });
           }
         });
+
+    if (displayVm != null) {
+      displayVm.addPropertyChangeListener(
+          evt -> {
+            if (DisplayViewModel.PROP_EQUALIZE_SORT_DURATION.equals(evt.getPropertyName())) {
+              VmBindings.runFx(refreshLabels);
+            }
+          });
+    }
 
     VmBindings.bindInputsEnabled(
         slider,
@@ -89,13 +133,58 @@ public final class SpeedSection {
         vm::addPropertyChangeListener,
         SpeedViewModel.PROP_INPUTS_ENABLED);
 
-    VBox root = new VBox(SettingsLayout.GAP_SM, header, sliderBlock);
+    VBox root =
+        equalize != null
+            ? new VBox(SettingsLayout.GAP_SM, header, sliderBlock, equalize)
+            : new VBox(SettingsLayout.GAP_SM, header, sliderBlock);
     root.setId(ROOT_ID);
     return root;
   }
 
-  private static String formatLevel(int level) {
+  private static void applyTickLabels(Slider slider, boolean equalize) {
+    StringConverter<Double> formatter =
+        new StringConverter<>() {
+          @Override
+          public String toString(Double n) {
+            if (n == null) {
+              return "";
+            }
+            return SettingsDefaults.speedTickLabel((int) Math.round(n), equalize);
+          }
+
+          @Override
+          public Double fromString(String s) {
+            return Double.NaN;
+          }
+        };
+    // JDK-8286653: skin ignores formatter changes unless cleared to null first.
+    slider.setLabelFormatter(null);
+    slider.setLabelFormatter(formatter);
+  }
+
+  private static boolean equalizeOn(DisplayViewModel displayVm) {
+    return displayVm != null && displayVm.isEqualizeSortDuration();
+  }
+
+  private static String headerText(boolean equalize) {
+    return equalize ? SettingsStrings.SPEED_DURATION_HEADER : SettingsStrings.SPEED_HEADER;
+  }
+
+  private static String slowText(boolean equalize) {
+    return equalize ? SettingsStrings.SPEED_EQUALIZE_SLOW : SettingsStrings.SPEED_SLOW;
+  }
+
+  private static String fastText(boolean equalize) {
+    return equalize ? SettingsStrings.SPEED_EQUALIZE_FAST : SettingsStrings.SPEED_FAST;
+  }
+
+  private static String formatValue(int level, boolean equalize) {
+    if (equalize) {
+      return String.format(
+          SettingsStrings.SPEED_DURATION_VALUE_FORMAT,
+          Math.round(SettingsDefaults.equalizedDurationSec(level)));
+    }
     return String.format(
-        SettingsStrings.SPEED_LEVEL_FORMAT, level, SettingsDefaults.SPEED_LEVEL_MAX);
+        SettingsStrings.SPEED_STEPS_VALUE_FORMAT, SettingsDefaults.stepsPerFrame(level));
   }
 }

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/VisualizationSection.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/VisualizationSection.java
@@ -64,7 +64,8 @@ public final class VisualizationSection {
 
     Button resetAll = new Button(SettingsStrings.RESET_ALL_VISUALS);
     resetAll.setId(RESET_ALL_BUTTON_ID);
-    resetAll.getStyleClass().add(Styles.BUTTON_OUTLINED);
+    resetAll.getStyleClass().add("settings-secondary-action");
+    resetAll.setTooltip(new Tooltip(SettingsStrings.RESET_ALL_VISUALS_TOOLTIP));
     resetAll.setOnAction(
         e -> {
           if (confirmResetAll(resetAll.getScene().getWindow())) {
@@ -105,6 +106,13 @@ public final class VisualizationSection {
         });
 
     path.setOnAction(e -> vm.setImagePath(Path.of(path.getText().trim())));
+    path.focusedProperty()
+        .addListener(
+            (obs, wasFocused, isFocused) -> {
+              if (wasFocused && !isFocused) {
+                vm.setImagePath(Path.of(path.getText().trim()));
+              }
+            });
 
     Label error = new Label(vm.getImageError());
     error.getStyleClass().add("settings-inline-error");

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/vm/ArraySizeViewModel.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/vm/ArraySizeViewModel.java
@@ -3,6 +3,7 @@ package io.github.compilerstuck.control.ui.settingsfx.vm;
 import io.github.compilerstuck.control.AppContext;
 import io.github.compilerstuck.control.catalog.VisualConstraints;
 import io.github.compilerstuck.control.config.SettingsDefaults;
+import io.github.compilerstuck.control.ui.settingsfx.SettingsStrings;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.util.function.Supplier;
@@ -79,7 +80,7 @@ public final class ArraySizeViewModel {
       validationMessage = "";
     } else {
       textValid = false;
-      validationMessage = "Enter a whole number";
+      validationMessage = SettingsStrings.ARRAY_SIZE_WHOLE_NUMBER;
     }
     pcs.firePropertyChange(PROP_TEXT, oldText, text);
     pcs.firePropertyChange(PROP_TEXT_VALID, oldValid, textValid);

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/vm/DisplayViewModel.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/vm/DisplayViewModel.java
@@ -16,6 +16,7 @@ public final class DisplayViewModel {
   public static final String PROP_PRINT_MEASUREMENTS = "printMeasurements";
   public static final String PROP_SHOW_COMPARISON_TABLE = "showComparisonTable";
   public static final String PROP_FIVE_SECOND_START_DELAY = "fiveSecondStartDelay";
+  public static final String PROP_EQUALIZE_SORT_DURATION = "equalizeSortDuration";
   public static final String PROP_CAN_EXPORT = "canExport";
   public static final String PROP_INPUTS_ENABLED = "inputsEnabled";
 
@@ -25,6 +26,7 @@ public final class DisplayViewModel {
   private boolean printMeasurements;
   private boolean showComparisonTable;
   private boolean fiveSecondStartDelay;
+  private boolean equalizeSortDuration;
   private boolean inputsEnabled = true;
 
   public DisplayViewModel(AppContext app) {
@@ -32,6 +34,7 @@ public final class DisplayViewModel {
     this.printMeasurements = app.getStateManager().shouldPrintMeasurements();
     this.showComparisonTable = app.getStateManager().shouldShowComparisonTable();
     this.fiveSecondStartDelay = app.isFiveSecondStartDelay();
+    this.equalizeSortDuration = app.isEqualizeSortDuration();
   }
 
   public boolean isPrintMeasurements() {
@@ -75,6 +78,20 @@ public final class DisplayViewModel {
     fiveSecondStartDelay = enabled;
     app.setFiveSecondStartDelay(enabled);
     pcs.firePropertyChange(PROP_FIVE_SECOND_START_DELAY, old, enabled);
+  }
+
+  public boolean isEqualizeSortDuration() {
+    return equalizeSortDuration;
+  }
+
+  public void setEqualizeSortDuration(boolean enabled) {
+    if (!inputsEnabled || equalizeSortDuration == enabled) {
+      return;
+    }
+    boolean old = equalizeSortDuration;
+    equalizeSortDuration = enabled;
+    app.setEqualizeSortDuration(enabled);
+    pcs.firePropertyChange(PROP_EQUALIZE_SORT_DURATION, old, enabled);
   }
 
   public boolean canExport() {

--- a/src/main/java/io/github/compilerstuck/sortingalgorithms/GravitySort.java
+++ b/src/main/java/io/github/compilerstuck/sortingalgorithms/GravitySort.java
@@ -2,7 +2,19 @@ package io.github.compilerstuck.sortingalgorithms;
 
 import io.github.compilerstuck.control.model.ArrayModel;
 
+/**
+ * Gravity (bead) sort. Beads are placed on an abacus and fall column-by-column.
+ *
+ * <p>Uses the classic {@code int[n][max]} abacus when it fits in a modest heap budget. Falls back
+ * to an O(n + max) simulation when {@code n * max} would risk {@link OutOfMemoryError}.
+ *
+ * <p>Each settled column ends with {@link #delayFrame} so the snapshot shows every bar updating
+ * together — the FrameGate steps-per-frame budget would otherwise skip many columns per draw.
+ */
 public class GravitySort extends SortingAlgorithm {
+
+  /** Cap on {@code n * max} abacus cells (~64 MiB of ints) before using the sparse path. */
+  private static final long ABACUS_CELL_LIMIT = 16_000_000L;
 
   public GravitySort(ArrayModel arrayController) {
     super(arrayController);
@@ -14,15 +26,34 @@ public class GravitySort extends SortingAlgorithm {
   public void sort() {
     report(name);
 
+    int n = arrayController.getLength();
+    if (n == 0) {
+      return;
+    }
+
     int max = arrayController.get(0);
-    for (int i = 1; i < arrayController.getLength() && !isCancelled(); i++)
+    for (int i = 1; i < n && !isCancelled(); i++) {
       if (arrayController.get(i) > max) {
         max = arrayController.get(i);
         arrayController.addComparisons(1);
       }
+    }
 
-    int[][] abacus = new int[arrayController.getLength()][max];
-    for (int i = 0; i < arrayController.getLength() && !isCancelled(); i++) {
+    if (max <= 0) {
+      return;
+    }
+
+    if ((long) n * (long) max <= ABACUS_CELL_LIMIT) {
+      sortWithAbacus(n, max);
+    } else {
+      sortSparse(n, max);
+    }
+  }
+
+  /** Original abacus implementation (same control flow as on {@code main}). */
+  private void sortWithAbacus(int n, int max) {
+    int[][] abacus = new int[n][max];
+    for (int i = 0; i < n && !isCancelled(); i++) {
       for (int j = 0; j < arrayController.get(i); j++) {
         arrayController.addComparisons(1);
         abacus[i][abacus[0].length - j - 1] = 1;
@@ -35,7 +66,9 @@ public class GravitySort extends SortingAlgorithm {
         if (abacus[j][i] == 1) {
           // Drop it
           int droppos = j;
-          while (droppos + 1 < abacus.length && abacus[droppos][i] == 1) droppos++;
+          while (droppos + 1 < abacus.length && abacus[droppos][i] == 1) {
+            droppos++;
+          }
           if (abacus[droppos][i] == 0) {
             abacus[j][i] = 0;
             abacus[droppos][i] = 1;
@@ -44,14 +77,64 @@ public class GravitySort extends SortingAlgorithm {
         }
       }
 
-      int count;
       for (int x = 0; x < abacus.length && !isCancelled(); x++) {
-        count = 0;
-        for (int y = 0; y < abacus[0].length; y++) count += abacus[x][y];
+        int count = 0;
+        for (int y = 0; y < abacus[0].length; y++) {
+          count += abacus[x][y];
+        }
         arrayController.set(x, count);
       }
 
-      delay(new int[] {arrayController.getLength() - i - 1});
+      delayFrame(new int[] {n - i - 1});
     }
+  }
+
+  /**
+   * Memory-safe path: same per-column bar heights as the abacus recount, without allocating {@code
+   * int[n][max]}.
+   */
+  private void sortSparse(int n, int max) {
+    int[] original = new int[n];
+    for (int i = 0; i < n; i++) {
+      original[i] = arrayController.get(i);
+      for (int j = 0; j < original[i]; j++) {
+        arrayController.addComparisons(1);
+        arrayController.addWritesAux(1);
+      }
+    }
+
+    int[] colBeads = new int[max];
+    for (int i = 0; i < n && !isCancelled(); i++) {
+      int value = original[i];
+      if (value > 0) {
+        colBeads[max - value]++;
+      }
+    }
+    for (int col = 1; col < max; col++) {
+      colBeads[col] += colBeads[col - 1];
+    }
+
+    for (int col = 0; col < max && !isCancelled(); col++) {
+      int unsettledCap = max - col - 1;
+      for (int row = 0; row < n && !isCancelled(); row++) {
+        int count = settledBeads(colBeads, col, n - row) + Math.min(original[row], unsettledCap);
+        arrayController.set(row, count);
+      }
+      delayFrame(new int[] {n - col - 1});
+    }
+  }
+
+  private static int settledBeads(int[] colBeads, int col, int need) {
+    int lo = 0;
+    int hi = col + 1;
+    while (lo < hi) {
+      int mid = (lo + hi) >>> 1;
+      if (colBeads[mid] >= need) {
+        hi = mid;
+      } else {
+        lo = mid + 1;
+      }
+    }
+    return lo <= col ? col - lo + 1 : 0;
   }
 }

--- a/src/main/java/io/github/compilerstuck/sortingalgorithms/GravitySort.java
+++ b/src/main/java/io/github/compilerstuck/sortingalgorithms/GravitySort.java
@@ -10,16 +10,76 @@ import io.github.compilerstuck.control.model.ArrayModel;
  *
  * <p>Each settled column ends with {@link #delayFrame} so the snapshot shows every bar updating
  * together — the FrameGate steps-per-frame budget would otherwise skip many columns per draw.
+ *
+ * <p>Under equalize-sort-duration mode, {@link #setColumnStride(int)} may skip intermediate columns
+ * so large arrays (e.g. 100k) can finish near the target time instead of doing O(n·max) bar
+ * rewrites.
  */
 public class GravitySort extends SortingAlgorithm {
 
   /** Cap on {@code n * max} abacus cells (~64 MiB of ints) before using the sparse path. */
   private static final long ABACUS_CELL_LIMIT = 16_000_000L;
 
+  /** Visualize every Nth column (1 = every column). Set by equalize pacing for large n. */
+  private int columnStride = 1;
+
   public GravitySort(ArrayModel arrayController) {
     super(arrayController);
     this.name = "Gravity Sort";
     alternativeSize = arrayController.getLength();
+  }
+
+  /**
+   * How many {@link #delayFrame} beats this sort will fire for {@code model} at stride 1: one per
+   * bead column ({@code max} value).
+   */
+  public static int estimateFrameBeats(ArrayModel model) {
+    return Math.max(0, maxValue(model));
+  }
+
+  /** Number of visualized columns when sampling with {@code stride}. */
+  public static int countVisualBeats(int maxColumns, int stride) {
+    if (maxColumns <= 0) {
+      return 0;
+    }
+    int s = Math.max(1, stride);
+    int count = 0;
+    int lastVis = -1;
+    for (int col = s - 1; col < maxColumns; col += s) {
+      count++;
+      lastVis = col;
+    }
+    if (lastVis != maxColumns - 1) {
+      count++;
+    }
+    return count;
+  }
+
+  /**
+   * Stride for equalize mode: show every Nth column (and always the last). {@code 1} restores full
+   * fidelity.
+   */
+  public void setColumnStride(int stride) {
+    this.columnStride = Math.max(1, stride);
+  }
+
+  public int getColumnStride() {
+    return columnStride;
+  }
+
+  private static int maxValue(ArrayModel model) {
+    int n = model.getLength();
+    if (n == 0) {
+      return 0;
+    }
+    int max = model.get(0);
+    for (int i = 1; i < n; i++) {
+      int v = model.get(i);
+      if (v > max) {
+        max = v;
+      }
+    }
+    return max;
   }
 
   @Override
@@ -77,6 +137,10 @@ public class GravitySort extends SortingAlgorithm {
         }
       }
 
+      if (!shouldVisualizeColumn(i, max)) {
+        continue;
+      }
+
       for (int x = 0; x < abacus.length && !isCancelled(); x++) {
         int count = 0;
         for (int y = 0; y < abacus[0].length; y++) {
@@ -91,15 +155,16 @@ public class GravitySort extends SortingAlgorithm {
 
   /**
    * Memory-safe path: same per-column bar heights as the abacus recount, without allocating {@code
-   * int[n][max]}.
+   * int[n][max]}. Intermediate columns may be skipped when {@link #columnStride} &gt; 1.
    */
   private void sortSparse(int n, int max) {
     int[] original = new int[n];
     for (int i = 0; i < n; i++) {
       original[i] = arrayController.get(i);
-      for (int j = 0; j < original[i]; j++) {
-        arrayController.addComparisons(1);
-        arrayController.addWritesAux(1);
+      // O(1) instrumentation (avoid O(value) loops that are O(n²) on 0..n-1 data).
+      if (original[i] > 0) {
+        arrayController.addComparisons(original[i]);
+        arrayController.addWritesAux(original[i]);
       }
     }
 
@@ -114,14 +179,37 @@ public class GravitySort extends SortingAlgorithm {
       colBeads[col] += colBeads[col - 1];
     }
 
-    for (int col = 0; col < max && !isCancelled(); col++) {
-      int unsettledCap = max - col - 1;
-      for (int row = 0; row < n && !isCancelled(); row++) {
-        int count = settledBeads(colBeads, col, n - row) + Math.min(original[row], unsettledCap);
-        arrayController.set(row, count);
-      }
+    int stride = columnStride;
+    int lastVis = -1;
+    for (int col = stride - 1; col < max && !isCancelled(); col += stride) {
+      writeSparseColumn(n, max, original, colBeads, col);
       delayFrame(new int[] {n - col - 1});
+      lastVis = col;
     }
+    int last = max - 1;
+    if (lastVis != last && !isCancelled()) {
+      writeSparseColumn(n, max, original, colBeads, last);
+      delayFrame(new int[] {n - last - 1});
+    }
+  }
+
+  private void writeSparseColumn(int n, int max, int[] original, int[] colBeads, int col) {
+    int unsettledCap = max - col - 1;
+    for (int row = 0; row < n && !isCancelled(); row++) {
+      int count = settledBeads(colBeads, col, n - row) + Math.min(original[row], unsettledCap);
+      arrayController.set(row, count);
+    }
+  }
+
+  private boolean shouldVisualizeColumn(int col, int maxColumns) {
+    int stride = columnStride;
+    if (stride <= 1) {
+      return true;
+    }
+    if (col == maxColumns - 1) {
+      return true;
+    }
+    return col % stride == stride - 1;
   }
 
   private static int settledBeads(int[] colBeads, int col, int need) {

--- a/src/main/java/io/github/compilerstuck/sortingalgorithms/QuickSortDualPivot.java
+++ b/src/main/java/io/github/compilerstuck/sortingalgorithms/QuickSortDualPivot.java
@@ -23,8 +23,12 @@ public class QuickSortDualPivot extends SortingAlgorithm {
     sort(arrayController, 0, arrayController.getLength() - 1);
   }
 
+  /**
+   * Dual-pivot quicksort. Recurses on the two smaller partitions and iterates on the largest so
+   * stack depth stays O(log n) even when outermost pivots degenerate (sorted / reverse input).
+   */
   private void sort(ArrayModel arrayController, int left, int right) {
-    if (right > left && !isCancelled()) {
+    while (right > left && !isCancelled()) {
       // Choose outermost elements as pivots
       if (arrayController.get(left) > arrayController.get(right)) {
         arrayController.swap(left, right);
@@ -75,10 +79,44 @@ public class QuickSortDualPivot extends SortingAlgorithm {
 
       delay(new int[] {left, right, l, g});
 
-      // Recursively sort partitions
-      sort(arrayController, left, l - 1);
-      sort(arrayController, l + 1, g - 1);
-      sort(arrayController, g + 1, right);
+      int leftLo = left;
+      int leftHi = l - 1;
+      int midLo = l + 1;
+      int midHi = g - 1;
+      int rightLo = g + 1;
+      int rightHi = right;
+
+      int leftLen = Math.max(0, leftHi - leftLo + 1);
+      int midLen = Math.max(0, midHi - midLo + 1);
+      int rightLen = Math.max(0, rightHi - rightLo + 1);
+
+      // Recurse into the two smaller segments; continue the loop on the largest.
+      if (leftLen >= midLen && leftLen >= rightLen) {
+        if (midLen > 0) {
+          sort(arrayController, midLo, midHi);
+        }
+        if (rightLen > 0) {
+          sort(arrayController, rightLo, rightHi);
+        }
+        right = leftHi;
+      } else if (midLen >= rightLen) {
+        if (leftLen > 0) {
+          sort(arrayController, leftLo, leftHi);
+        }
+        if (rightLen > 0) {
+          sort(arrayController, rightLo, rightHi);
+        }
+        left = midLo;
+        right = midHi;
+      } else {
+        if (leftLen > 0) {
+          sort(arrayController, leftLo, leftHi);
+        }
+        if (midLen > 0) {
+          sort(arrayController, midLo, midHi);
+        }
+        left = rightLo;
+      }
     }
   }
 }

--- a/src/main/java/io/github/compilerstuck/sortingalgorithms/SortingAlgorithm.java
+++ b/src/main/java/io/github/compilerstuck/sortingalgorithms/SortingAlgorithm.java
@@ -109,6 +109,22 @@ public abstract class SortingAlgorithm {
    * not included in {@link ArrayModel#getRealTime()}.
    */
   public void delay(int[] markers) {
+    pace(markers, false);
+  }
+
+  /**
+   * Like {@link #delay(int[])}, but forces one published frame (see {@link
+   * DelayContext#delayFrame()}).
+   */
+  public void delayFrame(int[] markers) {
+    pace(markers, true);
+  }
+
+  public void delay() {
+    delay(new int[0]);
+  }
+
+  private void pace(int[] markers, boolean wholeFrame) {
     if (isCancelled()) {
       return;
     }
@@ -123,12 +139,12 @@ public abstract class SortingAlgorithm {
         arrayController.setMarker(i, Marker.SET);
       }
 
-      proc.delay();
+      if (wholeFrame) {
+        proc.delayFrame();
+      } else {
+        proc.delay();
+      }
       startTime = System.nanoTime();
     }
-  }
-
-  public void delay() {
-    delay(new int[0]);
   }
 }

--- a/src/main/resources/css/settings-app.css
+++ b/src/main/resources/css/settings-app.css
@@ -38,6 +38,30 @@
   -fx-padding: 0 0 0 0;
 }
 
+.settings-option-group-label {
+  -fx-font-size: 0.7em;
+  -fx-font-weight: bold;
+  -fx-text-fill: -color-fg-muted;
+  -fx-letter-spacing: 0.03em;
+}
+
+.settings-secondary-action {
+  -fx-text-fill: -color-fg-muted;
+  -fx-background-color: transparent;
+  -fx-border-color: transparent;
+  -fx-padding: 4 8;
+  -fx-cursor: hand;
+}
+
+.settings-secondary-action:hover {
+  -fx-text-fill: -color-fg-default;
+  -fx-background-color: -color-bg-subtle;
+}
+
+.settings-secondary-action:disabled {
+  -fx-opacity: 0.5;
+}
+
 /* Sections separated by column GAP_XL; no extra bottom pad (avoids fighting the stack gap). */
 .settings-section {
   -fx-padding: 0;

--- a/src/main/resources/shaders/instance_lit.frag
+++ b/src/main/resources/shaders/instance_lit.frag
@@ -1,4 +1,4 @@
-precision mediump float;
+precision highp float;
 
 in vec4 v_color;
 out vec4 fragColor;

--- a/src/main/resources/shaders/instance_lit.vert
+++ b/src/main/resources/shaders/instance_lit.vert
@@ -1,4 +1,4 @@
-precision mediump float;
+precision highp float;
 
 in vec3 a_position;
 in vec3 a_normal;
@@ -23,7 +23,8 @@ void main() {
 
   mat3 worldN = mat3(world);
   vec3 n = normalize(worldN * a_normal);
-  float ndl = max(dot(n, normalize(-u_lightDir)), 0.0);
+  // Two-sided: quads are drawn without culling, so back faces need light too.
+  float ndl = abs(dot(n, normalize(-u_lightDir)));
   vec3 lit = u_ambient + u_lightColor * ndl;
   v_color = vec4(clamp(lit, 0.0, 1.0) * i_color.rgb, i_color.a);
 }

--- a/src/test/java/io/github/compilerstuck/control/config/AppConfigTest.java
+++ b/src/test/java/io/github/compilerstuck/control/config/AppConfigTest.java
@@ -17,4 +17,28 @@ class AppConfigTest {
         AppConfig.SHUFFLE_VISUAL_STEPS / 2,
         AppConfig.shuffleStepsForDelta(AppConfig.SHUFFLE_DURATION_SEC / 2f));
   }
+
+  @Test
+  void equalizedSortStepsForDeltaMatchesBudget() {
+    assertEquals(1, AppConfig.equalizedSortStepsForDelta(0f, 1000, 10f));
+    assertEquals(1, AppConfig.equalizedSortStepsForDelta(1f, 0, 10f));
+    assertEquals(100, AppConfig.equalizedSortStepsForDelta(1f, 1000, 10f));
+    assertEquals(50, AppConfig.equalizedSortStepsForDelta(0.5f, 1000, 10f));
+  }
+
+  @Test
+  void effectiveEqualizeTargetRespectsFrameFloor() {
+    assertEquals(0f, AppConfig.equalizeFrameFloorSec(0));
+    assertEquals(2f, AppConfig.equalizeFrameFloorSec(120), 1e-4f);
+    assertEquals(10f, AppConfig.effectiveEqualizeTargetSec(10f, 0));
+    assertEquals(10f, AppConfig.effectiveEqualizeTargetSec(10f, 120));
+    assertEquals(21.3333f, AppConfig.effectiveEqualizeTargetSec(10f, 1280), 1e-3f);
+  }
+
+  @Test
+  void equalizeMaxFrameBeatsScalesWithArrayLength() {
+    assertEquals(2, AppConfig.equalizeMaxFrameBeatsPerFrame(100_000));
+    assertEquals(64, AppConfig.equalizeMaxFrameBeatsPerFrame(1_000));
+    assertEquals(1, AppConfig.equalizeMaxFrameBeatsPerFrame(1_000_000));
+  }
 }

--- a/src/test/java/io/github/compilerstuck/control/config/SettingsDefaultsTest.java
+++ b/src/test/java/io/github/compilerstuck/control/config/SettingsDefaultsTest.java
@@ -16,7 +16,7 @@ class SettingsDefaultsTest {
     assertEquals("quicksort-middle", SettingsDefaults.DEFAULT_ALGORITHM_ID);
     assertEquals("bars", SettingsDefaults.DEFAULT_VISUALIZATION_ID);
     assertEquals(1280, SettingsDefaults.DEFAULT_ARRAY_SIZE);
-    assertEquals(3, SettingsDefaults.DEFAULT_SPEED_LEVEL);
+    assertEquals(5, SettingsDefaults.DEFAULT_SPEED_LEVEL);
     assertFalse(SettingsDefaults.DEFAULT_MUTED);
     assertFalse(SettingsDefaults.DEFAULT_PERF_STATS);
     assertFalse(SettingsDefaults.DEFAULT_FIVE_SECOND_START_DELAY);
@@ -27,13 +27,18 @@ class SettingsDefaultsTest {
     assertEquals(24, SettingsDefaults.ARRAY_SIZE_FPS_WARNING_THRESHOLD);
     assertEquals(20_000, SettingsDefaults.ARRAY_SIZE_HIGH_WARNING_THRESHOLD);
     assertEquals(1, SettingsDefaults.SPEED_LEVEL_MIN);
-    assertEquals(5, SettingsDefaults.SPEED_LEVEL_MAX);
+    assertEquals(10, SettingsDefaults.SPEED_LEVEL_MAX);
 
     assertEquals(1, SettingsDefaults.stepsPerFrame(1));
-    assertEquals(5, SettingsDefaults.stepsPerFrame(2));
-    assertEquals(25, SettingsDefaults.stepsPerFrame(3));
-    assertEquals(200, SettingsDefaults.stepsPerFrame(4));
-    assertEquals(2000, SettingsDefaults.stepsPerFrame(5));
+    assertEquals(2, SettingsDefaults.stepsPerFrame(2));
+    assertEquals(5, SettingsDefaults.stepsPerFrame(3));
+    assertEquals(12, SettingsDefaults.stepsPerFrame(4));
+    assertEquals(25, SettingsDefaults.stepsPerFrame(5));
+    assertEquals(50, SettingsDefaults.stepsPerFrame(6));
+    assertEquals(100, SettingsDefaults.stepsPerFrame(7));
+    assertEquals(250, SettingsDefaults.stepsPerFrame(8));
+    assertEquals(750, SettingsDefaults.stepsPerFrame(9));
+    assertEquals(2000, SettingsDefaults.stepsPerFrame(10));
   }
 
   @Test
@@ -43,8 +48,8 @@ class SettingsDefaultsTest {
     assertEquals(1280, SettingsDefaults.clampArraySize(1280));
 
     assertEquals(1, SettingsDefaults.clampSpeedLevel(0));
-    assertEquals(5, SettingsDefaults.clampSpeedLevel(9));
-    assertEquals(3, SettingsDefaults.clampSpeedLevel(3));
+    assertEquals(10, SettingsDefaults.clampSpeedLevel(99));
+    assertEquals(5, SettingsDefaults.clampSpeedLevel(5));
   }
 
   @Test

--- a/src/test/java/io/github/compilerstuck/control/config/SettingsDefaultsTest.java
+++ b/src/test/java/io/github/compilerstuck/control/config/SettingsDefaultsTest.java
@@ -2,6 +2,7 @@ package io.github.compilerstuck.control.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -39,6 +40,18 @@ class SettingsDefaultsTest {
     assertEquals(250, SettingsDefaults.stepsPerFrame(8));
     assertEquals(750, SettingsDefaults.stepsPerFrame(9));
     assertEquals(2000, SettingsDefaults.stepsPerFrame(10));
+
+    assertTrue(SettingsDefaults.DEFAULT_EQUALIZE_SORT_DURATION);
+    assertEquals(30f, SettingsDefaults.equalizedDurationSec(1));
+    assertEquals(10f, SettingsDefaults.equalizedDurationSec(5));
+    assertEquals(2f, SettingsDefaults.equalizedDurationSec(10));
+
+    assertEquals("1", SettingsDefaults.speedTickLabel(1, false));
+    assertEquals("25", SettingsDefaults.speedTickLabel(5, false));
+    assertEquals("2k", SettingsDefaults.speedTickLabel(10, false));
+    assertEquals("30s", SettingsDefaults.speedTickLabel(1, true));
+    assertEquals("10s", SettingsDefaults.speedTickLabel(5, true));
+    assertEquals("2s", SettingsDefaults.speedTickLabel(10, true));
   }
 
   @Test

--- a/src/test/java/io/github/compilerstuck/control/config/UserPreferencesTest.java
+++ b/src/test/java/io/github/compilerstuck/control/config/UserPreferencesTest.java
@@ -44,6 +44,7 @@ class UserPreferencesTest {
     assertTrue(prefs.getRunAllEntriesList().isEmpty());
     assertFalse(prefs.isPerfStats());
     assertFalse(prefs.isFiveSecondStartDelay());
+    assertTrue(prefs.isEqualizeSortDuration());
   }
 
   @Test
@@ -63,6 +64,7 @@ class UserPreferencesTest {
             new RunAllEntryPref("quicksort-middle", false)));
     prefs.setPerfStats(true);
     prefs.setFiveSecondStartDelay(true);
+    prefs.setEqualizeSortDuration(false);
     prefs.save(node);
 
     UserPreferences loaded = UserPreferences.load(node);
@@ -82,6 +84,7 @@ class UserPreferencesTest {
     assertFalse(entries.get(1).selected());
     assertTrue(loaded.isPerfStats());
     assertTrue(loaded.isFiveSecondStartDelay());
+    assertFalse(loaded.isEqualizeSortDuration());
   }
 
   @Test

--- a/src/test/java/io/github/compilerstuck/control/model/EqualizePacingTest.java
+++ b/src/test/java/io/github/compilerstuck/control/model/EqualizePacingTest.java
@@ -1,0 +1,76 @@
+package io.github.compilerstuck.control.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.compilerstuck.control.config.AppConfig;
+import org.junit.jupiter.api.Test;
+
+class EqualizePacingTest {
+
+  @Test
+  void beginWithZeroStepsLeavesInactive() {
+    EqualizePacing pacing = new EqualizePacing();
+    pacing.begin(0, 0, 10f);
+    assertFalse(pacing.isActive());
+    assertEquals(-1, pacing.stepsForDelta(1f / 60f));
+  }
+
+  @Test
+  void stepsForDeltaUsesRemainingBudget() {
+    EqualizePacing pacing = new EqualizePacing();
+    pacing.begin(600, 0, 10f);
+    assertTrue(pacing.isActive());
+    // 600 steps / 10s → 60 steps/s → ~1 step per 1/60s frame
+    assertEquals(1, pacing.stepsForDelta(1f / 60f));
+    for (int i = 0; i < 300; i++) {
+      pacing.recordStep();
+    }
+    // Half consumed; still ~1/frame if on schedule
+    assertEquals(1, pacing.stepsForDelta(1f / 60f));
+  }
+
+  @Test
+  void shortTargetWithFrameBeatsEnablesBatching() {
+    EqualizePacing pacing = new EqualizePacing();
+    // 120 beats → floor 2s; slider 1s → must batch
+    pacing.begin(120, 120, 1f, 120);
+    assertTrue(pacing.batchBeats());
+    assertEquals(1f, pacing.effectiveTargetSec(), 1e-4f);
+    // Uncapped: 120 steps / 1s → 2 per 1/60s frame; n=120 allows up to 64
+    assertEquals(2, pacing.stepsForDelta(1f / 60f));
+  }
+
+  @Test
+  void largeArrayCapsBatchedBeatsPerFrame() {
+    EqualizePacing pacing = new EqualizePacing();
+    pacing.begin(100_000, 100_000, 2f, 100_000);
+    assertTrue(pacing.batchBeats());
+    assertEquals(2, pacing.maxStepsPerFrame()); // 250_000 / 100_000
+    // Schedule wants huge grants; cap keeps frames responsive
+    assertEquals(2, pacing.stepsForDelta(1f / 60f));
+  }
+
+  @Test
+  void longTargetStretchesWithExtraFrameWaits() {
+    EqualizePacing pacing = new EqualizePacing();
+    // 60 beats → floor 1s; slider 2s → ~2 frames per beat on average
+    pacing.begin(60, 60, 2f);
+    assertFalse(pacing.batchBeats());
+    int extras = 0;
+    for (int i = 0; i < 60; i++) {
+      extras += pacing.takeExtraFrameWaits();
+    }
+    // 2s * 60fps = 120 frames total → 60 beats + ~60 extras
+    assertEquals(60, extras);
+  }
+
+  @Test
+  void frameFloorHelperUnchanged() {
+    assertEquals(2f, AppConfig.equalizeFrameFloorSec(120), 1e-4f);
+    assertEquals(2f, AppConfig.effectiveEqualizeTargetSec(1f, 120), 1e-4f);
+    assertEquals(2, AppConfig.equalizeMaxFrameBeatsPerFrame(100_000));
+    assertEquals(64, AppConfig.equalizeMaxFrameBeatsPerFrame(1_000));
+  }
+}

--- a/src/test/java/io/github/compilerstuck/control/model/EqualizeSortDurationSessionTest.java
+++ b/src/test/java/io/github/compilerstuck/control/model/EqualizeSortDurationSessionTest.java
@@ -1,0 +1,260 @@
+package io.github.compilerstuck.control.model;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.compilerstuck.control.config.ShuffleType;
+import io.github.compilerstuck.control.render.CountingDelayContext;
+import io.github.compilerstuck.control.render.DelayContext;
+import io.github.compilerstuck.sortingalgorithms.BogoSort;
+import io.github.compilerstuck.sortingalgorithms.BubbleSort;
+import io.github.compilerstuck.sortingalgorithms.GravitySort;
+import io.github.compilerstuck.sortingalgorithms.SortingAlgorithm;
+import io.github.compilerstuck.sound.Sound;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class EqualizeSortDurationSessionTest {
+
+  private static final DelayContext NO_OP = () -> {};
+
+  private ArrayController array;
+  private SortingStateManager stateManager;
+  private SortingSessionManager sessionManager;
+
+  @BeforeEach
+  void setUp() {
+    array = new ArrayController(32);
+    stateManager = new SortingStateManager();
+    FakeSound sound = new FakeSound(array);
+    sessionManager = new SortingSessionManager(array, sound, stateManager, 0, 0);
+    sessionManager.setEqualizeSupport(() -> true, () -> 10.0, () -> NO_OP);
+  }
+
+  @Test
+  @DisplayName("dry-run restores array and arms equalize pacing with counted steps")
+  void dryRunRestoresAndArmsPacing() {
+    reverseInPlace(array);
+    int[] before = Arrays.copyOf(array.getArray(), array.getLength());
+
+    CountingSortStub algorithm = new CountingSortStub(array, 7);
+    assertTrue(sessionManager.tryArmEqualizePacing(algorithm, NO_OP));
+
+    assertArrayEquals(before, array.getArray());
+    assertEquals(0, array.getComparisons());
+    assertEquals(0, array.getSwaps());
+    assertEquals(0, array.getWrites());
+    assertTrue(stateManager.equalizePacing().isActive());
+    assertEquals(7, stateManager.equalizePacing().totalSteps());
+    assertEquals(0, stateManager.equalizePacing().frameBeats());
+    assertEquals(10f, stateManager.equalizePacing().effectiveTargetSec());
+  }
+
+  @Test
+  @DisplayName("Bogo Sort is skipped for equalization")
+  void bogoIsSkipped() {
+    BogoSort bogo = new BogoSort(array);
+    assertFalse(sessionManager.tryArmEqualizePacing(bogo, NO_OP));
+    assertFalse(stateManager.equalizePacing().isActive());
+  }
+
+  @Test
+  @DisplayName("Bubble Sort visual steps differ strongly by shuffle type")
+  void bubbleStepsVaryByShuffle() {
+    int n = 40;
+    ArrayController almost = new ArrayController(n);
+    almost.setShuffleType(ShuffleType.ALMOST_SORTED);
+    shuffleSilent(almost);
+
+    ArrayController reverse = new ArrayController(n);
+    reverse.setShuffleType(ShuffleType.REVERSE);
+    shuffleSilent(reverse);
+
+    long almostSteps = countSteps(new BubbleSort(almost), almost);
+    long reverseSteps = countSteps(new BubbleSort(reverse), reverse);
+
+    assertTrue(
+        reverseSteps > almostSteps * 5, () -> "reverse=" + reverseSteps + " almost=" + almostSteps);
+  }
+
+  @Test
+  @DisplayName("Gravity Sort equalize uses stride so large-n budgets stay near the target")
+  void gravityEqualizeUsesStrideForBudget() {
+    array = new ArrayController(120);
+    reverseInPlace(array);
+    FakeSound sound = new FakeSound(array);
+    sessionManager = new SortingSessionManager(array, sound, stateManager, 0, 0);
+    sessionManager.setEqualizeSupport(() -> true, () -> 1.0, () -> NO_OP);
+
+    int natural = GravitySort.estimateFrameBeats(array);
+    assertEquals(119, natural);
+
+    GravitySort gravity = new GravitySort(array);
+    assertTrue(sessionManager.tryArmEqualizePacing(gravity, NO_OP));
+
+    // budget = maxPerFrame(120)*60*1 ≈ 64*60 = 3840 > 119 → stride 1
+    assertEquals(1, gravity.getColumnStride());
+    EqualizePacing pacing = stateManager.equalizePacing();
+    assertEquals(natural, pacing.totalSteps());
+    assertTrue(pacing.batchBeats());
+  }
+
+  @Test
+  @DisplayName("Gravity equalize at 100k uses a large stride and few visual beats")
+  void gravityEqualizeLargeNUsesLargeStride() {
+    array = new ArrayController(10_000);
+    reverseInPlace(array);
+    FakeSound sound = new FakeSound(array);
+    sessionManager = new SortingSessionManager(array, sound, stateManager, 0, 0);
+    sessionManager.setEqualizeSupport(() -> true, () -> 2.0, () -> NO_OP);
+
+    GravitySort gravity = new GravitySort(array);
+    assertTrue(sessionManager.tryArmEqualizePacing(gravity, NO_OP));
+
+    assertTrue(gravity.getColumnStride() > 1);
+    EqualizePacing pacing = stateManager.equalizePacing();
+    assertTrue(pacing.totalSteps() < 5_000, () -> "visual beats=" + pacing.totalSteps());
+    assertEquals(
+        GravitySort.countVisualBeats(
+            GravitySort.estimateFrameBeats(array), gravity.getColumnStride()),
+        pacing.totalSteps());
+  }
+
+  @Test
+  @DisplayName("Gravity sparse path with stride still finishes sorted")
+  void gravityStrideStillSorts() {
+    ArrayController big = new ArrayController(200);
+    reverseInPlace(big);
+    // Force sparse path
+    GravitySort gravity = new GravitySort(big);
+    gravity.setColumnStride(17);
+    gravity.setDelay(false);
+    gravity.sort();
+    assertTrue(big.isSorted());
+  }
+
+  @Test
+  @DisplayName("non-Gravity dry-run suspends FrameGate and drains leftover credits")
+  void dryRunSuspendsFrameGate() throws Exception {
+    FrameGate gate = new FrameGate();
+    sessionManager.setFrameGate(gate);
+    gate.grant(50);
+
+    SlowCountingStub slow = new SlowCountingStub(array, 3, 80);
+    boolean[] sawSuspended = {false};
+    Thread sampler =
+        new Thread(
+            () -> {
+              long deadline = System.nanoTime() + 2_000_000_000L;
+              while (System.nanoTime() < deadline) {
+                if (stateManager.isFrameGateSuspended()) {
+                  sawSuspended[0] = true;
+                  return;
+                }
+                Thread.onSpinWait();
+              }
+            },
+            "suspend-sampler");
+    sampler.start();
+    assertTrue(sessionManager.tryArmEqualizePacing(slow, NO_OP));
+    sampler.join(3000);
+    assertTrue(sawSuspended[0], "dry-run should suspend FrameGate while counting");
+    assertFalse(stateManager.isFrameGateSuspended());
+    assertEquals(0, gate.availableCredits());
+  }
+
+  @Test
+  @DisplayName("restoreContents copies without bumping write counters")
+  void restoreContentsDoesNotCountWrites() {
+    int[] snapshot = Arrays.copyOf(array.getArray(), array.getLength());
+    array.swap(0, array.getLength() - 1);
+    long writes = array.getWrites();
+    array.restoreContents(snapshot);
+    assertEquals(writes, array.getWrites());
+    assertArrayEquals(snapshot, array.getArray());
+  }
+
+  private static long countSteps(SortingAlgorithm algorithm, ArrayController model) {
+    CountingDelayContext counter = new CountingDelayContext();
+    algorithm.setDelayContext(counter);
+    algorithm.setDelay(true);
+    algorithm.sort();
+    return counter.stepCount();
+  }
+
+  private static void shuffleSilent(ArrayController model) {
+    model.setDelayContext(NO_OP);
+    model.setOperationReporter(OperationReporter.NOOP);
+    model.shuffle();
+  }
+
+  private static void reverseInPlace(ArrayController model) {
+    int n = model.getLength();
+    for (int i = 0; i < n / 2; i++) {
+      int a = model.get(i);
+      int b = model.get(n - 1 - i);
+      // avoid swap counters for setup clarity
+      model.getArray()[i] = b;
+      model.getArray()[n - 1 - i] = a;
+    }
+  }
+
+  private static final class FakeSound extends Sound {
+    FakeSound(ArrayModel arrayModel) {
+      super(arrayModel);
+    }
+
+    @Override
+    public void playSound(int index) {}
+
+    @Override
+    public void mute(boolean mute) {}
+  }
+
+  /** Deterministic algorithm that fires a fixed number of delay() calls. */
+  private static final class CountingSortStub extends SortingAlgorithm {
+    private final int steps;
+
+    CountingSortStub(ArrayModel model, int steps) {
+      super(model, NO_OP);
+      this.steps = steps;
+      this.name = "CountingSortStub";
+    }
+
+    @Override
+    public void sort() {
+      for (int i = 0; i < steps && !isCancelled(); i++) {
+        delay();
+      }
+    }
+  }
+
+  /** Like {@link CountingSortStub} but sleeps so a sampler can observe FrameGate suspension. */
+  private static final class SlowCountingStub extends SortingAlgorithm {
+    private final int steps;
+    private final long sleepMs;
+
+    SlowCountingStub(ArrayModel model, int steps, long sleepMs) {
+      super(model, NO_OP);
+      this.steps = steps;
+      this.sleepMs = sleepMs;
+      this.name = "SlowCountingStub";
+    }
+
+    @Override
+    public void sort() {
+      try {
+        Thread.sleep(sleepMs);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      for (int i = 0; i < steps && !isCancelled(); i++) {
+        delay();
+      }
+    }
+  }
+}

--- a/src/test/java/io/github/compilerstuck/control/model/FrameGateTest.java
+++ b/src/test/java/io/github/compilerstuck/control/model/FrameGateTest.java
@@ -167,4 +167,39 @@ class FrameGateTest {
     assertEquals(0, gate.availableCredits());
     assertFalse(gate.isCancelled());
   }
+
+  @Test
+  @DisplayName("drain then awaitStep yields one visible frame despite multi-credit grant")
+  void drainThenAwaitGivesOneFrame() throws InterruptedException {
+    FrameGate gate = new FrameGate();
+    AtomicInteger columns = new AtomicInteger();
+    java.util.concurrent.CountDownLatch firstColumnReady =
+        new java.util.concurrent.CountDownLatch(1);
+    Thread sorter =
+        new Thread(
+            () -> {
+              try {
+                for (int i = 0; i < 3; i++) {
+                  columns.incrementAndGet(); // settle column (like GravitySort rewrite)
+                  if (i == 0) {
+                    firstColumnReady.countDown();
+                  }
+                  gate.drain(); // delayFrame: force publish
+                  gate.awaitStep();
+                }
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+            },
+            "gravity-frame-sorter");
+    sorter.start();
+    assertTrue(firstColumnReady.await(2, java.util.concurrent.TimeUnit.SECONDS));
+    for (int expected = 1; expected <= 3; expected++) {
+      gate.awaitIdle();
+      assertEquals(expected, columns.get(), "one column per published frame");
+      gate.grant(25); // default speed budget — must not skip columns
+    }
+    sorter.join(2000);
+    assertEquals(3, columns.get());
+  }
 }

--- a/src/test/java/io/github/compilerstuck/control/model/FrameGateTest.java
+++ b/src/test/java/io/github/compilerstuck/control/model/FrameGateTest.java
@@ -173,17 +173,17 @@ class FrameGateTest {
   void drainThenAwaitGivesOneFrame() throws InterruptedException {
     FrameGate gate = new FrameGate();
     AtomicInteger columns = new AtomicInteger();
-    java.util.concurrent.CountDownLatch firstColumnReady =
-        new java.util.concurrent.CountDownLatch(1);
+    java.util.concurrent.CountDownLatch column1 = new java.util.concurrent.CountDownLatch(1);
+    java.util.concurrent.CountDownLatch column2 = new java.util.concurrent.CountDownLatch(1);
+    java.util.concurrent.CountDownLatch column3 = new java.util.concurrent.CountDownLatch(1);
+    java.util.concurrent.CountDownLatch[] columnReady = {column1, column2, column3};
     Thread sorter =
         new Thread(
             () -> {
               try {
                 for (int i = 0; i < 3; i++) {
                   columns.incrementAndGet(); // settle column (like GravitySort rewrite)
-                  if (i == 0) {
-                    firstColumnReady.countDown();
-                  }
+                  columnReady[i].countDown();
                   gate.drain(); // delayFrame: force publish
                   gate.awaitStep();
                 }
@@ -193,13 +193,36 @@ class FrameGateTest {
             },
             "gravity-frame-sorter");
     sorter.start();
-    assertTrue(firstColumnReady.await(2, java.util.concurrent.TimeUnit.SECONDS));
     for (int expected = 1; expected <= 3; expected++) {
-      gate.awaitIdle();
+      assertTrue(
+          columnReady[expected - 1].await(2, java.util.concurrent.TimeUnit.SECONDS),
+          "column " + expected + " should settle");
       assertEquals(expected, columns.get(), "one column per published frame");
+      // Grant only after awaitStep is blocking; otherwise drain can wipe a premature grant and
+      // awaitIdle returns with columns still unchanged (flake under CI scheduling).
+      waitUntilWaiting(sorter);
+      gate.awaitIdle();
       gate.grant(25); // default speed budget — must not skip columns
     }
     sorter.join(2000);
+    assertFalse(sorter.isAlive());
     assertEquals(3, columns.get());
+  }
+
+  /** Waits until {@code thread} is blocked in {@code Object.wait} (e.g. FrameGate.awaitStep). */
+  private static void waitUntilWaiting(Thread thread) throws InterruptedException {
+    long deadline = System.nanoTime() + java.util.concurrent.TimeUnit.SECONDS.toNanos(2);
+    while (System.nanoTime() < deadline) {
+      Thread.State state = thread.getState();
+      if (state == Thread.State.WAITING || state == Thread.State.TIMED_WAITING) {
+        Thread.sleep(1);
+        state = thread.getState();
+        if (state == Thread.State.WAITING || state == Thread.State.TIMED_WAITING) {
+          return;
+        }
+      }
+      Thread.onSpinWait();
+    }
+    fail("thread did not block in awaitStep: state=" + thread.getState());
   }
 }

--- a/src/test/java/io/github/compilerstuck/control/render/CountingDelayContextTest.java
+++ b/src/test/java/io/github/compilerstuck/control/render/CountingDelayContextTest.java
@@ -1,0 +1,45 @@
+package io.github.compilerstuck.control.render;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+class CountingDelayContextTest {
+
+  @Test
+  void countsDelayAndDelayFrameSeparately() {
+    CountingDelayContext ctx = new CountingDelayContext();
+    ctx.delay();
+    ctx.delay();
+    ctx.delayFrame();
+    assertEquals(3, ctx.stepCount());
+    assertEquals(1, ctx.frameBeatCount());
+    assertFalse(ctx.timedOut());
+  }
+
+  @Test
+  void timeoutInvokesAbortCallback() {
+    AtomicBoolean aborted = new AtomicBoolean();
+    CountingDelayContext ctx =
+        new CountingDelayContext(System.nanoTime() - 1, null, () -> aborted.set(true));
+    ctx.delay();
+    assertTrue(ctx.timedOut());
+    assertTrue(aborted.get());
+    assertEquals(0, ctx.stepCount());
+  }
+
+  @Test
+  void externalCancelAbortsWithoutTimeout() {
+    AtomicBoolean aborted = new AtomicBoolean();
+    CountingDelayContext ctx =
+        new CountingDelayContext(Long.MAX_VALUE, () -> true, () -> aborted.set(true));
+    ctx.delayFrame();
+    assertTrue(ctx.aborted());
+    assertFalse(ctx.timedOut());
+    assertTrue(aborted.get());
+    assertEquals(0, ctx.frameBeatCount());
+  }
+}

--- a/src/test/java/io/github/compilerstuck/control/render/TrackingDelayContextTest.java
+++ b/src/test/java/io/github/compilerstuck/control/render/TrackingDelayContextTest.java
@@ -1,0 +1,77 @@
+package io.github.compilerstuck.control.render;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.compilerstuck.control.model.EqualizePacing;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class TrackingDelayContextTest {
+
+  @Test
+  void batchingUsesPlainDelayWithoutDrain() {
+    AtomicInteger delayCalls = new AtomicInteger();
+    AtomicInteger delayFrameCalls = new AtomicInteger();
+    DelayContext inner =
+        new DelayContext() {
+          @Override
+          public void delay() {
+            delayCalls.incrementAndGet();
+          }
+
+          @Override
+          public void delayFrame() {
+            delayFrameCalls.incrementAndGet();
+          }
+        };
+
+    EqualizePacing pacing = new EqualizePacing();
+    pacing.begin(120, 120, 1f); // floor 2s, target 1s → batch
+    assertTrue(pacing.batchBeats());
+
+    TrackingDelayContext tracking = new TrackingDelayContext(inner, pacing);
+    tracking.delayFrame();
+    tracking.delayFrame();
+
+    assertEquals(2, delayCalls.get());
+    assertEquals(0, delayFrameCalls.get());
+    assertEquals(2, pacing.frameBeatsConsumed());
+  }
+
+  @Test
+  void nonBatchingDelayFrameInvokesDelegateDelayFramePlusExtras() {
+    AtomicInteger delayCalls = new AtomicInteger();
+    AtomicInteger delayFrameCalls = new AtomicInteger();
+    DelayContext inner =
+        new DelayContext() {
+          @Override
+          public void delay() {
+            delayCalls.incrementAndGet();
+          }
+
+          @Override
+          public void delayFrame() {
+            delayFrameCalls.incrementAndGet();
+          }
+        };
+
+    EqualizePacing pacing = new EqualizePacing();
+    pacing.begin(60, 60, 2f); // stretch → ~1 extra frame per beat on average
+
+    TrackingDelayContext tracking = new TrackingDelayContext(inner, pacing);
+    tracking.delayFrame();
+
+    assertEquals(0, delayCalls.get());
+    assertTrue(delayFrameCalls.get() >= 1);
+    assertEquals(1, pacing.frameBeatsConsumed());
+
+    int extrasOverRun = delayFrameCalls.get() - 1;
+    for (int i = 0; i < 59; i++) {
+      int before = delayFrameCalls.get();
+      tracking.delayFrame();
+      extrasOverRun += delayFrameCalls.get() - before - 1;
+    }
+    assertEquals(60, extrasOverRun);
+  }
+}

--- a/src/test/java/io/github/compilerstuck/control/ui/settingsfx/SettingsShellSmokeTest.java
+++ b/src/test/java/io/github/compilerstuck/control/ui/settingsfx/SettingsShellSmokeTest.java
@@ -102,7 +102,7 @@ class SettingsShellSmokeTest extends ApplicationTest {
         new SectionNodes(
             ArraySizeSection.build(arrayVm),
             SortingSection.build(new AlgorithmViewModel(fx.app)),
-            SpeedSection.build(new SpeedViewModel(fx.app)),
+            SpeedSection.build(new SpeedViewModel(fx.app), new DisplayViewModel(fx.app)),
             VisualizationSection.build(vizVm),
             AppearanceSection.build(new AppearanceViewModel(fx.app)),
             OptionsSection.build(

--- a/src/test/java/io/github/compilerstuck/control/ui/settingsfx/vm/DisplayViewModelTest.java
+++ b/src/test/java/io/github/compilerstuck/control/ui/settingsfx/vm/DisplayViewModelTest.java
@@ -24,6 +24,7 @@ class DisplayViewModelTest {
     assertTrue(vm.isPrintMeasurements());
     assertFalse(vm.isShowComparisonTable());
     assertFalse(vm.isFiveSecondStartDelay());
+    assertTrue(vm.isEqualizeSortDuration());
 
     vm.setPrintMeasurements(false);
     assertFalse(fx.app.getStateManager().shouldPrintMeasurements());
@@ -33,6 +34,9 @@ class DisplayViewModelTest {
 
     vm.setFiveSecondStartDelay(true);
     assertTrue(fx.app.isFiveSecondStartDelay());
+
+    vm.setEqualizeSortDuration(false);
+    assertFalse(fx.app.isEqualizeSortDuration());
   }
 
   @Test
@@ -48,5 +52,7 @@ class DisplayViewModelTest {
     assertFalse(vm.isShowComparisonTable());
     vm.setFiveSecondStartDelay(true);
     assertFalse(vm.isFiveSecondStartDelay());
+    vm.setEqualizeSortDuration(false);
+    assertTrue(vm.isEqualizeSortDuration());
   }
 }

--- a/src/test/java/io/github/compilerstuck/control/ui/settingsfx/vm/PersistenceViewModelTest.java
+++ b/src/test/java/io/github/compilerstuck/control/ui/settingsfx/vm/PersistenceViewModelTest.java
@@ -27,9 +27,11 @@ class PersistenceViewModelTest {
     fx.app.setPrintMeasurements(false);
     fx.app.setShowComparisonTable(true);
     fx.app.setFiveSecondStartDelay(true);
+    fx.app.setEqualizeSortDuration(true);
     assertFalse(fx.app.getPreferences().isPrintMeasurements());
     assertTrue(fx.app.getPreferences().isShowComparisonTable());
     assertTrue(fx.app.getPreferences().isFiveSecondStartDelay());
+    assertTrue(fx.app.getPreferences().isEqualizeSortDuration());
   }
 
   @Test

--- a/src/test/java/io/github/compilerstuck/control/ui/settingsfx/vm/SpeedViewModelTest.java
+++ b/src/test/java/io/github/compilerstuck/control/ui/settingsfx/vm/SpeedViewModelTest.java
@@ -24,9 +24,9 @@ class SpeedViewModelTest {
 
   @Test
   void setSpeedLevelPropagates() {
-    vm.setSpeedLevel(5);
-    assertEquals(5, vm.getSpeedLevel());
-    assertEquals(5, fx.app.getSpeedLevel());
+    vm.setSpeedLevel(10);
+    assertEquals(10, vm.getSpeedLevel());
+    assertEquals(10, fx.app.getSpeedLevel());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Add equalize-sort-duration pacing so sorts can target a shared wall-clock duration, with related Settings wiring and tests.
- Expand the speed slider to levels 1–10 and update defaults/prefs accordingly.
- Polish the Settings Run Deck: toggle tooltips, Options Display/Audio/Debug grouping, image-path commit on focus-lost, softer Reset all, responsive column stacking below 640px viewport width, and string cleanup.

## Test plan
- [ ] `./mvnw --batch-mode test` (or at least SettingsShellSmokeTest, EqualizePacingTest, EqualizeSortDurationSessionTest, SpeedViewModelTest, ArraySizeViewModelTest)
- [ ] Settings: hover Options/Run-all/Sound tooltips; confirm Display/Audio/Debug micro-headers
- [ ] Resize Settings under ~640px viewport width → columns stack; widen → side-by-side
- [ ] Image visualization: type a path, Tab away → path applies without Enter
- [ ] Customize stays outlined; Reset all is muted with explanatory tooltip + confirm dialog
- [ ] Enable equalize sort duration; run a few algorithms and confirm pacing toward the target duration