### PR TITLE
feat: add Dark/White canvas background option

### DIFF
--- a/src/main/java/io/github/compilerstuck/control/AppContext.java
+++ b/src/main/java/io/github/compilerstuck/control/AppContext.java
@@ -1,5 +1,6 @@
 package io.github.compilerstuck.control;
 
+import io.github.compilerstuck.control.config.CanvasBackground;
 import io.github.compilerstuck.control.config.RunAllEntryPref;
 import io.github.compilerstuck.control.config.SettingsDefaults;
 import io.github.compilerstuck.control.config.ShuffleType;
@@ -55,6 +56,7 @@ public final class AppContext {
   private boolean perfStatsEnabled;
   private boolean fiveSecondStartDelay;
   private boolean equalizeSortDuration;
+  private CanvasBackground canvasBackground;
 
   public AppContext(
       ArrayController arrayController,
@@ -70,6 +72,7 @@ public final class AppContext {
     this.perfStatsEnabled = this.preferences.isPerfStats();
     this.fiveSecondStartDelay = this.preferences.isFiveSecondStartDelay();
     this.equalizeSortDuration = this.preferences.isEqualizeSortDuration();
+    this.canvasBackground = this.preferences.getCanvasBackground();
     if (sessionManager != null) {
       sessionManager.setFrameGate(frameGate);
       sessionManager.setEqualizeSupport(
@@ -96,6 +99,7 @@ public final class AppContext {
     preferences.setPerfStats(perfStatsEnabled);
     preferences.setFiveSecondStartDelay(fiveSecondStartDelay);
     preferences.setEqualizeSortDuration(equalizeSortDuration);
+    preferences.setCanvasBackground(canvasBackground);
     if (colorGradient != null) {
       preferences.setGradientName(colorGradient.getName());
       if (colorGradient.getColor1() != null) {
@@ -189,6 +193,7 @@ public final class AppContext {
     this.colorGradient = colorGradient;
     if (this.colorGradient != null) {
       this.colorGradient.updateGradient(size);
+      applyCanvasBackgroundToGradient();
       preferences.setGradientName(this.colorGradient.getName());
       if (this.colorGradient.getColor1() != null) {
         preferences.setGradientColor1Rgb(this.colorGradient.getColor1().getRGB());
@@ -281,6 +286,7 @@ public final class AppContext {
   public void setGraphics(RenderSystem renderSystem, DelayContext delay) {
     this.renderSystem = renderSystem;
     this.delayContext = delay;
+    applyCanvasBackgroundToRenderSystem();
   }
 
   /** Resizes the array and dependent components; refuses while a sort is running. */
@@ -387,6 +393,38 @@ public final class AppContext {
     equalizeSortDuration = enabled;
     preferences.setEqualizeSortDuration(enabled);
     preferences.save();
+  }
+
+  public CanvasBackground getCanvasBackground() {
+    return canvasBackground;
+  }
+
+  public void setCanvasBackground(CanvasBackground background) {
+    CanvasBackground next =
+        background != null ? background : SettingsDefaults.DEFAULT_CANVAS_BACKGROUND;
+    if (canvasBackground == next) {
+      return;
+    }
+    canvasBackground = next;
+    preferences.setCanvasBackground(next);
+    preferences.save();
+    applyCanvasBackgroundToGradient();
+    applyCanvasBackgroundToRenderSystem();
+  }
+
+  private void applyCanvasBackgroundToGradient() {
+    if (colorGradient == null || canvasBackground == null) {
+      return;
+    }
+    colorGradient.setLightBackgroundMarkerOverride(
+        canvasBackground.isLight() ? canvasBackground.markerSetFallback() : null);
+  }
+
+  private void applyCanvasBackgroundToRenderSystem() {
+    if (renderSystem == null || canvasBackground == null) {
+      return;
+    }
+    renderSystem.setOverlayTextGray(canvasBackground.overlayTextGray());
   }
 
   public void setShuffleType(ShuffleType shuffleType) {

--- a/src/main/java/io/github/compilerstuck/control/SortingVisualizerGame.java
+++ b/src/main/java/io/github/compilerstuck/control/SortingVisualizerGame.java
@@ -6,6 +6,7 @@ import io.github.compilerstuck.control.catalog.AlgorithmCatalog;
 import io.github.compilerstuck.control.catalog.AlgorithmDescriptor;
 import io.github.compilerstuck.control.catalog.VisualizationCatalog;
 import io.github.compilerstuck.control.catalog.VisualizationDescriptor;
+import io.github.compilerstuck.control.config.CanvasBackground;
 import io.github.compilerstuck.control.config.GradientPreferences;
 import io.github.compilerstuck.control.config.UserPreferences;
 import io.github.compilerstuck.control.model.ArrayController;
@@ -205,7 +206,11 @@ public final class SortingVisualizerGame extends Game {
   }
 
   public void drawWorld(float delta) {
-    renderSystem.clear(15 / 255f, 15 / 255f, 15 / 255f);
+    CanvasBackground background =
+        appContext != null ? appContext.getCanvasBackground() : CanvasBackground.DARK;
+    float clear = background.clearComponent();
+    renderSystem.clear(clear, clear, clear);
+    renderSystem.setOverlayTextGray(background.overlayTextGray());
     currentVisualization().render(delta);
   }
 

--- a/src/main/java/io/github/compilerstuck/control/config/AppConfig.java
+++ b/src/main/java/io/github/compilerstuck/control/config/AppConfig.java
@@ -84,9 +84,15 @@ public final class AppConfig {
   /** Upper bound on batched frame-beats granted in one draw frame. */
   public static final int EQUALIZE_MAX_FRAME_BEATS_PER_FRAME = 64;
 
-  // Visualization
-  public static final int RESULTS_TABLE_BACKGROUND = 15;
-  public static final int RESULTS_TABLE_TEXT_COLOR = 255;
+  // Visualization / canvas
+  /** Default (dark) canvas clear gray — RGB {@code #0F0F0F}. */
+  public static final int CANVAS_BACKGROUND_DARK = 15;
+
+  /** Alternate canvas clear gray — RGB {@code #FFFFFF}. */
+  public static final int CANVAS_BACKGROUND_WHITE = 255;
+
+  public static final int RESULTS_TABLE_BACKGROUND = CANVAS_BACKGROUND_DARK;
+  public static final int RESULTS_TABLE_TEXT_COLOR = CANVAS_BACKGROUND_WHITE;
   public static final int FONT_SIZE_RATIO = 20;
   public static final int WINDOW_RATIO_WIDTH = 1280;
 

--- a/src/main/java/io/github/compilerstuck/control/config/CanvasBackground.java
+++ b/src/main/java/io/github/compilerstuck/control/config/CanvasBackground.java
@@ -1,0 +1,71 @@
+package io.github.compilerstuck.control.config;
+
+import java.awt.Color;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/** Canvas clear color choice: near-black default or pure white. */
+public enum CanvasBackground {
+  DARK("Dark", AppConfig.CANVAS_BACKGROUND_DARK, AppConfig.CANVAS_BACKGROUND_WHITE),
+  WHITE("White", AppConfig.CANVAS_BACKGROUND_WHITE, AppConfig.CANVAS_BACKGROUND_DARK);
+
+  private static final Logger LOGGER = Logger.getLogger(CanvasBackground.class.getName());
+
+  private final String label;
+  private final int clearGray;
+  private final int overlayTextGray;
+
+  CanvasBackground(String label, int clearGray, int overlayTextGray) {
+    this.label = label;
+    this.clearGray = clearGray;
+    this.overlayTextGray = overlayTextGray;
+  }
+
+  public String label() {
+    return label;
+  }
+
+  /** 0–255 gray channel used for {@code clear(r,g,b)}. */
+  public int clearGray() {
+    return clearGray;
+  }
+
+  public float clearComponent() {
+    return clearGray / 255f;
+  }
+
+  /** 0–255 gray channel for HUD / results overlay text and grid lines. */
+  public int overlayTextGray() {
+    return overlayTextGray;
+  }
+
+  public boolean isLight() {
+    return this == WHITE;
+  }
+
+  /**
+   * When the canvas is light, opaque-white {@code Marker.SET} colors remapped to this so highlights
+   * stay visible.
+   */
+  public Color markerSetFallback() {
+    int g = AppConfig.CANVAS_BACKGROUND_DARK;
+    return new Color(g, g, g);
+  }
+
+  @Override
+  public String toString() {
+    return label;
+  }
+
+  public static CanvasBackground fromName(String raw) {
+    if (raw == null || raw.isBlank()) {
+      return SettingsDefaults.DEFAULT_CANVAS_BACKGROUND;
+    }
+    try {
+      return CanvasBackground.valueOf(raw.trim());
+    } catch (IllegalArgumentException ex) {
+      LOGGER.log(Level.WARNING, "Unknown canvasBackground ''{0}'', using default", raw);
+      return SettingsDefaults.DEFAULT_CANVAS_BACKGROUND;
+    }
+  }
+}

--- a/src/main/java/io/github/compilerstuck/control/config/SettingsDefaults.java
+++ b/src/main/java/io/github/compilerstuck/control/config/SettingsDefaults.java
@@ -29,6 +29,7 @@ public final class SettingsDefaults {
   public static final boolean DEFAULT_PERF_STATS = false;
   public static final boolean DEFAULT_FIVE_SECOND_START_DELAY = false;
   public static final boolean DEFAULT_EQUALIZE_SORT_DURATION = true;
+  public static final CanvasBackground DEFAULT_CANVAS_BACKGROUND = CanvasBackground.DARK;
 
   /** JSON map of visualizationId → settings object (see VisualizationSettingsCodec). */
   public static final String DEFAULT_VISUAL_SETTINGS_BY_ID = "{}";

--- a/src/main/java/io/github/compilerstuck/control/config/UserPreferences.java
+++ b/src/main/java/io/github/compilerstuck/control/config/UserPreferences.java
@@ -40,6 +40,7 @@ public final class UserPreferences {
   private static final String KEY_PERF_STATS = "perfStats";
   private static final String KEY_FIVE_SECOND_START_DELAY = "fiveSecondStartDelay";
   private static final String KEY_EQUALIZE_SORT_DURATION = "equalizeSortDuration";
+  private static final String KEY_CANVAS_BACKGROUND = "canvasBackground";
   private static final String KEY_VISUAL_SETTINGS_BY_ID = "visualSettingsById";
   private static final int CURRENT_DEFAULTS_VERSION = 1;
 
@@ -64,6 +65,7 @@ public final class UserPreferences {
   private boolean perfStats = SettingsDefaults.DEFAULT_PERF_STATS;
   private boolean fiveSecondStartDelay = SettingsDefaults.DEFAULT_FIVE_SECOND_START_DELAY;
   private boolean equalizeSortDuration = SettingsDefaults.DEFAULT_EQUALIZE_SORT_DURATION;
+  private CanvasBackground canvasBackground = SettingsDefaults.DEFAULT_CANVAS_BACKGROUND;
   private String visualSettingsById = SettingsDefaults.DEFAULT_VISUAL_SETTINGS_BY_ID;
 
   public static UserPreferences load() {
@@ -108,6 +110,9 @@ public final class UserPreferences {
     prefs.equalizeSortDuration =
         node.getBoolean(
             KEY_EQUALIZE_SORT_DURATION, SettingsDefaults.DEFAULT_EQUALIZE_SORT_DURATION);
+    prefs.canvasBackground =
+        CanvasBackground.fromName(
+            node.get(KEY_CANVAS_BACKGROUND, SettingsDefaults.DEFAULT_CANVAS_BACKGROUND.name()));
     prefs.visualSettingsById =
         node.get(KEY_VISUAL_SETTINGS_BY_ID, SettingsDefaults.DEFAULT_VISUAL_SETTINGS_BY_ID);
     if (prefs.visualSettingsById == null) {
@@ -142,6 +147,11 @@ public final class UserPreferences {
     node.putBoolean(KEY_PERF_STATS, perfStats);
     node.putBoolean(KEY_FIVE_SECOND_START_DELAY, fiveSecondStartDelay);
     node.putBoolean(KEY_EQUALIZE_SORT_DURATION, equalizeSortDuration);
+    node.put(
+        KEY_CANVAS_BACKGROUND,
+        canvasBackground != null
+            ? canvasBackground.name()
+            : SettingsDefaults.DEFAULT_CANVAS_BACKGROUND.name());
     node.put(
         KEY_VISUAL_SETTINGS_BY_ID,
         visualSettingsById != null
@@ -306,6 +316,15 @@ public final class UserPreferences {
 
   public void setEqualizeSortDuration(boolean equalizeSortDuration) {
     this.equalizeSortDuration = equalizeSortDuration;
+  }
+
+  public CanvasBackground getCanvasBackground() {
+    return canvasBackground;
+  }
+
+  public void setCanvasBackground(CanvasBackground canvasBackground) {
+    this.canvasBackground =
+        canvasBackground != null ? canvasBackground : SettingsDefaults.DEFAULT_CANVAS_BACKGROUND;
   }
 
   public String getVisualSettingsById() {

--- a/src/main/java/io/github/compilerstuck/control/render/GdxOverlayPass.java
+++ b/src/main/java/io/github/compilerstuck/control/render/GdxOverlayPass.java
@@ -1,7 +1,6 @@
 package io.github.compilerstuck.control.render;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
@@ -95,7 +94,7 @@ final class GdxOverlayPass implements Disposable {
     world2d.beginSprites();
     host.frameStats().textDraws++;
     BitmapFont font = assets.font(sizePx);
-    font.setColor(Color.WHITE);
+    font.setColor(host.overlayTextR(), host.overlayTextG(), host.overlayTextB(), 1f);
     float drawY = y - font.getCapHeight();
     font.draw(world2d.sprites(), text, x, drawY);
   }
@@ -109,7 +108,7 @@ final class GdxOverlayPass implements Disposable {
     enterOverlayPass();
     world2d.beginSprites();
     BitmapFont font = assets.font(sizePx);
-    font.setColor(Color.WHITE);
+    font.setColor(host.overlayTextR(), host.overlayTextG(), host.overlayTextB(), 1f);
     float cap = font.getCapHeight();
     SpriteBatch sprites = world2d.sprites();
     FrameStats frameStats = host.frameStats();
@@ -133,7 +132,7 @@ final class GdxOverlayPass implements Disposable {
     enterOverlayPass();
     world2d.beginSprites();
     BitmapFont font = assets.font(sizePx);
-    font.setColor(Color.WHITE);
+    font.setColor(host.overlayTextR(), host.overlayTextG(), host.overlayTextB(), 1f);
     float cap = font.getCapHeight();
     SpriteBatch sprites = world2d.sprites();
     FrameStats frameStats = host.frameStats();

--- a/src/main/java/io/github/compilerstuck/control/render/GdxRenderSystem.java
+++ b/src/main/java/io/github/compilerstuck/control/render/GdxRenderSystem.java
@@ -46,6 +46,9 @@ public final class GdxRenderSystem implements RenderSystem, Disposable {
   private final GdxOverlayPass overlay;
 
   private volatile Thread renderThread;
+  private float overlayTextR = 1f;
+  private float overlayTextG = 1f;
+  private float overlayTextB = 1f;
 
   public GdxRenderSystem(AppAssets assets) {
     Objects.requireNonNull(assets, "assets");
@@ -277,6 +280,26 @@ public final class GdxRenderSystem implements RenderSystem, Disposable {
   @Override
   public void drawText(String text, float x, float y, float sizePx) {
     overlay.drawText(text, x, y, sizePx);
+  }
+
+  @Override
+  public void setOverlayTextGray(int gray0to255) {
+    float c = Math.max(0, Math.min(255, gray0to255)) / 255f;
+    overlayTextR = c;
+    overlayTextG = c;
+    overlayTextB = c;
+  }
+
+  float overlayTextR() {
+    return overlayTextR;
+  }
+
+  float overlayTextG() {
+    return overlayTextG;
+  }
+
+  float overlayTextB() {
+    return overlayTextB;
   }
 
   @Override

--- a/src/main/java/io/github/compilerstuck/control/render/RenderSystem.java
+++ b/src/main/java/io/github/compilerstuck/control/render/RenderSystem.java
@@ -63,6 +63,12 @@ public interface RenderSystem {
   void drawText(String text, float x, float y, float sizePx);
 
   /**
+   * Overlay: gray channel (0–255) for subsequent {@link #drawText} / {@link #drawTexts} calls.
+   * Default implementations ignore the value (white text).
+   */
+  default void setOverlayTextGray(int gray0to255) {}
+
+  /**
    * Overlay: advance width of {@code text} at {@code sizePx}. Returns {@code 0} when unknown (e.g.
    * null/empty text).
    */

--- a/src/main/java/io/github/compilerstuck/control/screen/ResultsScreen.java
+++ b/src/main/java/io/github/compilerstuck/control/screen/ResultsScreen.java
@@ -5,6 +5,7 @@ import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputAdapter;
 import com.badlogic.gdx.Screen;
 import io.github.compilerstuck.control.SortingVisualizerGame;
+import io.github.compilerstuck.control.config.CanvasBackground;
 import io.github.compilerstuck.control.model.SortingStateManager;
 import io.github.compilerstuck.control.render.GdxRenderSystem;
 import io.github.compilerstuck.control.ui.ResultsTableRenderer;
@@ -76,8 +77,13 @@ public final class ResultsScreen implements Screen {
       }
 
       if (stateManager.shouldContinueExecution()) {
+        CanvasBackground background =
+            game.appContext() != null
+                ? game.appContext().getCanvasBackground()
+                : CanvasBackground.DARK;
         resultsTableRenderer.render(
             renderSystem,
+            background,
             game.currentAlgorithms(),
             game.sessionManager().getComparisons(),
             game.sessionManager().getRealTime(),

--- a/src/main/java/io/github/compilerstuck/control/ui/ResultsTableRenderer.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/ResultsTableRenderer.java
@@ -1,6 +1,7 @@
 package io.github.compilerstuck.control.ui;
 
 import io.github.compilerstuck.control.config.AppConfig;
+import io.github.compilerstuck.control.config.CanvasBackground;
 import io.github.compilerstuck.control.render.RenderSystem;
 import io.github.compilerstuck.sortingalgorithms.SortingAlgorithm;
 import java.util.List;
@@ -15,6 +16,7 @@ public final class ResultsTableRenderer {
 
   public void render(
       RenderSystem rs,
+      CanvasBackground background,
       List<SortingAlgorithm> algorithms,
       List<String> comparisons,
       List<String> realTime,
@@ -24,14 +26,16 @@ public final class ResultsTableRenderer {
     int width = rs.getWidth();
     int height = rs.getHeight();
 
-    float bg = AppConfig.RESULTS_TABLE_BACKGROUND / 255f;
-    rs.clear(bg, bg, bg);
+    CanvasBackground bg = background != null ? background : CanvasBackground.DARK;
+    float clear = bg.clearComponent();
+    rs.clear(clear, clear, clear);
+    rs.setOverlayTextGray(bg.overlayTextGray());
 
     float textSize = AppConfig.scaleToWidth(AppConfig.FONT_SIZE_RATIO, width);
     float topRow = AppConfig.scaleToWidth(AppConfig.TABLE_TOP_ROW, width);
     float cellPad = AppConfig.scaleToWidth(AppConfig.TABLE_CELL_PADDING, width);
 
-    drawGrid(rs, width, height);
+    drawGrid(rs, width, height, bg);
     drawHeaders(rs, width, textSize, cellPad);
     drawData(
         rs,
@@ -40,6 +44,7 @@ public final class ResultsTableRenderer {
         textSize,
         topRow,
         cellPad,
+        bg,
         algorithms,
         comparisons,
         realTime,
@@ -48,7 +53,7 @@ public final class ResultsTableRenderer {
         writesAux);
   }
 
-  private void drawGrid(RenderSystem rs, int width, int height) {
+  private void drawGrid(RenderSystem rs, int width, int height, CanvasBackground background) {
     float columnWidth = width * AppConfig.TABLE_COLUMN_WIDTH_RATIO;
     // 1 center divider + 5 column dividers
     int count = 6;
@@ -56,7 +61,7 @@ public final class ResultsTableRenderer {
       gridLines = new float[count * 4];
       gridArgb = new int[count];
     }
-    int textColor = packGray(AppConfig.RESULTS_TABLE_TEXT_COLOR);
+    int textColor = packGray(background.overlayTextGray());
 
     float x0 = columnWidth + columnWidth / 2;
     gridLines[0] = x0;
@@ -98,6 +103,7 @@ public final class ResultsTableRenderer {
       float textSize,
       float topRow,
       float cellPad,
+      CanvasBackground background,
       List<SortingAlgorithm> algorithms,
       List<String> comparisons,
       List<String> realTime,
@@ -110,7 +116,7 @@ public final class ResultsTableRenderer {
 
     float columnWidth = width * AppConfig.TABLE_COLUMN_WIDTH_RATIO;
     float rowHeight = (height - topRow) / algorithms.size();
-    int textColor = packGray(AppConfig.RESULTS_TABLE_TEXT_COLOR);
+    int textColor = packGray(background.overlayTextGray());
 
     if (rowLines == null || rowLines.length < algorithms.size() * 4) {
       rowLines = new float[algorithms.size() * 4];

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/AppearanceSection.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/AppearanceSection.java
@@ -1,5 +1,6 @@
 package io.github.compilerstuck.control.ui.settingsfx;
 
+import io.github.compilerstuck.control.config.CanvasBackground;
 import io.github.compilerstuck.control.ui.settingsfx.vm.AppearanceViewModel;
 import java.util.List;
 import javafx.scene.Node;
@@ -11,7 +12,7 @@ import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 
-/** Gradient preset combo + custom color pickers. */
+/** Gradient preset combo, canvas background, and custom color pickers. */
 public final class AppearanceSection {
 
   public static final String ROOT_ID = "section-appearance";
@@ -36,6 +37,25 @@ public final class AppearanceSection {
               }
             });
     VBox presetField = SettingsControls.labeledField(SettingsStrings.PRESET, presets);
+    HBox.setHgrow(presetField, Priority.ALWAYS);
+
+    ComboBox<CanvasBackground> background = new ComboBox<>();
+    background.getItems().setAll(vm.getCanvasBackgroundOptions());
+    background.getSelectionModel().select(vm.getCanvasBackground());
+    background.setMaxWidth(Double.MAX_VALUE);
+    background
+        .getSelectionModel()
+        .selectedItemProperty()
+        .addListener(
+            (obs, old, selected) -> {
+              if (selected != null && selected != vm.getCanvasBackground()) {
+                vm.setCanvasBackground(selected);
+              }
+            });
+    VBox backgroundField = SettingsControls.labeledField(SettingsStrings.BACKGROUND, background);
+    HBox.setHgrow(backgroundField, Priority.ALWAYS);
+
+    HBox presetRow = new HBox(SettingsLayout.GAP_SM, presetField, backgroundField);
 
     Label colorsLabel = SettingsControls.fieldLabel(SettingsStrings.COLORS);
     ColorPicker color1 = new ColorPicker(toFx(vm.getColor1()));
@@ -67,11 +87,24 @@ public final class AppearanceSection {
           } else if (AppearanceViewModel.PROP_COLOR2.equals(evt.getPropertyName())) {
             Color fx = toFx((java.awt.Color) evt.getNewValue());
             VmBindings.runFx(() -> color2.setValue(fx));
+          } else if (AppearanceViewModel.PROP_CANVAS_BACKGROUND.equals(evt.getPropertyName())) {
+            CanvasBackground value = (CanvasBackground) evt.getNewValue();
+            VmBindings.runFx(
+                () -> {
+                  if (background.getSelectionModel().getSelectedItem() != value) {
+                    background.getSelectionModel().select(value);
+                  }
+                });
           }
         });
 
     VmBindings.bindInputsEnabled(
         presets,
+        vm::isInputsEnabled,
+        vm::addPropertyChangeListener,
+        AppearanceViewModel.PROP_INPUTS_ENABLED);
+    VmBindings.bindInputsEnabled(
+        background,
         vm::isInputsEnabled,
         vm::addPropertyChangeListener,
         AppearanceViewModel.PROP_INPUTS_ENABLED);
@@ -86,7 +119,7 @@ public final class AppearanceSection {
         vm::addPropertyChangeListener,
         AppearanceViewModel.PROP_INPUTS_ENABLED);
 
-    VBox root = new VBox(SettingsLayout.GAP_SM, presetField, colorsField);
+    VBox root = new VBox(SettingsLayout.GAP_SM, presetRow, colorsField);
     root.setId(ROOT_ID);
     return root;
   }

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SettingsStrings.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SettingsStrings.java
@@ -28,6 +28,7 @@ public final class SettingsStrings {
   public static final String SPEED_HEADER = "Speed";
   public static final String SPEED_DURATION_HEADER = "Target duration";
   public static final String PRESET = "Preset";
+  public static final String BACKGROUND = "Background";
   public static final String IMAGE = "Image";
   public static final String COLORS = "Colors";
   public static final String SPEED_STEPS_VALUE_FORMAT = "%d steps/frame";

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/vm/AppearanceViewModel.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/vm/AppearanceViewModel.java
@@ -1,7 +1,9 @@
 package io.github.compilerstuck.control.ui.settingsfx.vm;
 
 import io.github.compilerstuck.control.AppContext;
+import io.github.compilerstuck.control.config.CanvasBackground;
 import io.github.compilerstuck.control.config.GradientPresets;
+import io.github.compilerstuck.control.config.SettingsDefaults;
 import io.github.compilerstuck.visual.gradient.ColorGradient;
 import java.awt.Color;
 import java.beans.PropertyChangeListener;
@@ -10,7 +12,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Headless appearance (gradient) view-model. Initializes from the live {@link
+ * Headless appearance (gradient + canvas background) view-model. Initializes from the live {@link
  * AppContext#getColorGradient()} rather than a hard-coded combo index.
  */
 public final class AppearanceViewModel {
@@ -18,6 +20,7 @@ public final class AppearanceViewModel {
   public static final String PROP_SELECTED_INDEX = "selectedIndex";
   public static final String PROP_COLOR1 = "color1";
   public static final String PROP_COLOR2 = "color2";
+  public static final String PROP_CANVAS_BACKGROUND = "canvasBackground";
   public static final String PROP_INPUTS_ENABLED = "inputsEnabled";
 
   private final AppContext app;
@@ -27,6 +30,7 @@ public final class AppearanceViewModel {
   private int selectedIndex;
   private Color color1;
   private Color color2;
+  private CanvasBackground canvasBackground;
   private boolean inputsEnabled = true;
 
   public AppearanceViewModel(AppContext app) {
@@ -42,6 +46,10 @@ public final class AppearanceViewModel {
       color1 = presets.get(0).getColor1();
       color2 = presets.get(0).getColor2();
     }
+    canvasBackground =
+        app.getCanvasBackground() != null
+            ? app.getCanvasBackground()
+            : SettingsDefaults.DEFAULT_CANVAS_BACKGROUND;
   }
 
   public List<ColorGradient> getPresets() {
@@ -50,6 +58,10 @@ public final class AppearanceViewModel {
 
   public List<String> getPresetNames() {
     return presets.stream().map(ColorGradient::getName).toList();
+  }
+
+  public List<CanvasBackground> getCanvasBackgroundOptions() {
+    return List.of(CanvasBackground.values());
   }
 
   public int getSelectedIndex() {
@@ -62,6 +74,10 @@ public final class AppearanceViewModel {
 
   public Color getColor2() {
     return color2;
+  }
+
+  public CanvasBackground getCanvasBackground() {
+    return canvasBackground;
   }
 
   public void selectPreset(int index) {
@@ -101,6 +117,16 @@ public final class AppearanceViewModel {
     pcs.firePropertyChange(PROP_SELECTED_INDEX, oldIdx, selectedIndex);
     pcs.firePropertyChange(PROP_COLOR1, old1, color1);
     pcs.firePropertyChange(PROP_COLOR2, old2, color2);
+  }
+
+  public void setCanvasBackground(CanvasBackground background) {
+    if (!inputsEnabled || background == null || background == canvasBackground) {
+      return;
+    }
+    CanvasBackground old = canvasBackground;
+    canvasBackground = background;
+    app.setCanvasBackground(background);
+    pcs.firePropertyChange(PROP_CANVAS_BACKGROUND, old, canvasBackground);
   }
 
   public boolean isInputsEnabled() {

--- a/src/main/java/io/github/compilerstuck/visual/gradient/ColorGradient.java
+++ b/src/main/java/io/github/compilerstuck/visual/gradient/ColorGradient.java
@@ -14,6 +14,12 @@ public class ColorGradient {
   private final String name;
   protected Color[] colorGradient;
 
+  /**
+   * When non-null, opaque-white {@link Marker#SET} colors resolve to this instead (light canvas
+   * contrast).
+   */
+  private Color lightBackgroundMarkerOverride;
+
   public ColorGradient(Color color1, Color color2, Color markerSetColor, String name) {
     this(color1, color2, markerSetColor, name, DEFAULT_SIZE);
   }
@@ -60,10 +66,33 @@ public class ColorGradient {
       }
       return gradient[i];
     } else if (m == Marker.SET) {
-      return markerSetColor;
+      return effectiveMarkerSetColor();
     } else {
       return Color.BLACK;
     }
+  }
+
+  /**
+   * On a light canvas, remaps opaque-white SET markers to {@code override} so highlights stay
+   * visible. Pass {@code null} to restore the preset marker color.
+   */
+  public void setLightBackgroundMarkerOverride(Color override) {
+    this.lightBackgroundMarkerOverride = override;
+  }
+
+  public Color getMarkerSetColor() {
+    return markerSetColor;
+  }
+
+  private Color effectiveMarkerSetColor() {
+    if (lightBackgroundMarkerOverride != null && isOpaqueWhite(markerSetColor)) {
+      return lightBackgroundMarkerOverride;
+    }
+    return markerSetColor;
+  }
+
+  private static boolean isOpaqueWhite(Color c) {
+    return c != null && c.getRed() == 255 && c.getGreen() == 255 && c.getBlue() == 255;
   }
 
   public void setColor1(Color color1) {

--- a/src/test/java/io/github/compilerstuck/control/config/SettingsDefaultsTest.java
+++ b/src/test/java/io/github/compilerstuck/control/config/SettingsDefaultsTest.java
@@ -42,6 +42,7 @@ class SettingsDefaultsTest {
     assertEquals(2000, SettingsDefaults.stepsPerFrame(10));
 
     assertTrue(SettingsDefaults.DEFAULT_EQUALIZE_SORT_DURATION);
+    assertEquals(CanvasBackground.DARK, SettingsDefaults.DEFAULT_CANVAS_BACKGROUND);
     assertEquals(30f, SettingsDefaults.equalizedDurationSec(1));
     assertEquals(10f, SettingsDefaults.equalizedDurationSec(5));
     assertEquals(2f, SettingsDefaults.equalizedDurationSec(10));

--- a/src/test/java/io/github/compilerstuck/control/config/UserPreferencesTest.java
+++ b/src/test/java/io/github/compilerstuck/control/config/UserPreferencesTest.java
@@ -45,6 +45,7 @@ class UserPreferencesTest {
     assertFalse(prefs.isPerfStats());
     assertFalse(prefs.isFiveSecondStartDelay());
     assertTrue(prefs.isEqualizeSortDuration());
+    assertEquals(SettingsDefaults.DEFAULT_CANVAS_BACKGROUND, prefs.getCanvasBackground());
   }
 
   @Test
@@ -65,6 +66,7 @@ class UserPreferencesTest {
     prefs.setPerfStats(true);
     prefs.setFiveSecondStartDelay(true);
     prefs.setEqualizeSortDuration(false);
+    prefs.setCanvasBackground(CanvasBackground.WHITE);
     prefs.save(node);
 
     UserPreferences loaded = UserPreferences.load(node);
@@ -85,14 +87,17 @@ class UserPreferencesTest {
     assertTrue(loaded.isPerfStats());
     assertTrue(loaded.isFiveSecondStartDelay());
     assertFalse(loaded.isEqualizeSortDuration());
+    assertEquals(CanvasBackground.WHITE, loaded.getCanvasBackground());
   }
 
   @Test
   void malformedShuffleAndRunAllFallBackSafely() {
     node.put("shuffleType", "NOT_A_REAL_SHUFFLE");
     node.put("runAllEntries", "bad-token,ok-id:1,:0,nope:");
+    node.put("canvasBackground", "NOT_A_BACKGROUND");
     UserPreferences prefs = UserPreferences.load(node);
     assertEquals(SettingsDefaults.DEFAULT_SHUFFLE_TYPE, prefs.getShuffleType());
+    assertEquals(SettingsDefaults.DEFAULT_CANVAS_BACKGROUND, prefs.getCanvasBackground());
     List<RunAllEntryPref> entries = prefs.getRunAllEntriesList();
     assertEquals(1, entries.size());
     assertEquals("ok-id", entries.get(0).id());

--- a/src/test/java/io/github/compilerstuck/control/ui/settingsfx/vm/AppearanceViewModelTest.java
+++ b/src/test/java/io/github/compilerstuck/control/ui/settingsfx/vm/AppearanceViewModelTest.java
@@ -3,6 +3,10 @@ package io.github.compilerstuck.control.ui.settingsfx.vm;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import io.github.compilerstuck.control.config.AppConfig;
+import io.github.compilerstuck.control.config.CanvasBackground;
+import io.github.compilerstuck.visual.Marker;
+import io.github.compilerstuck.visual.gradient.ColorGradient;
 import java.awt.Color;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,5 +53,29 @@ class AppearanceViewModelTest {
     vm.selectPreset(0);
     assertEquals(before, vm.getSelectedIndex());
     assertFalse(vm.isInputsEnabled());
+  }
+
+  @Test
+  void canvasBackgroundDefaultsToDark() {
+    assertEquals(CanvasBackground.DARK, vm.getCanvasBackground());
+  }
+
+  @Test
+  void setCanvasBackgroundUpdatesAppContextAndRemapsWhiteMarkers() {
+    ColorGradient gradient = fx.app.getColorGradient();
+    assertEquals(Color.WHITE, gradient.getMarkerColor(0, Marker.SET));
+
+    vm.setCanvasBackground(CanvasBackground.WHITE);
+    assertEquals(CanvasBackground.WHITE, fx.app.getCanvasBackground());
+    assertEquals(CanvasBackground.WHITE, fx.app.getPreferences().getCanvasBackground());
+    Color expected =
+        new Color(
+            AppConfig.CANVAS_BACKGROUND_DARK,
+            AppConfig.CANVAS_BACKGROUND_DARK,
+            AppConfig.CANVAS_BACKGROUND_DARK);
+    assertEquals(expected, gradient.getMarkerColor(0, Marker.SET));
+
+    vm.setCanvasBackground(CanvasBackground.DARK);
+    assertEquals(Color.WHITE, gradient.getMarkerColor(0, Marker.SET));
   }
 }

--- a/src/test/java/io/github/compilerstuck/control/ui/settingsfx/vm/PersistenceViewModelTest.java
+++ b/src/test/java/io/github/compilerstuck/control/ui/settingsfx/vm/PersistenceViewModelTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.github.compilerstuck.control.config.CanvasBackground;
 import io.github.compilerstuck.control.config.RunAllEntryPref;
 import io.github.compilerstuck.control.config.ShuffleType;
 import io.github.compilerstuck.visual.gradient.ColorGradient;
@@ -49,6 +50,12 @@ class PersistenceViewModelTest {
     assertEquals("Custom Gradient", fx.app.getPreferences().getGradientName());
     assertEquals(Color.YELLOW.getRGB(), fx.app.getPreferences().getGradientColor1Rgb());
     assertEquals(Color.CYAN.getRGB(), fx.app.getPreferences().getGradientColor2Rgb());
+  }
+
+  @Test
+  void canvasBackgroundPersistsOnAppContext() {
+    fx.app.setCanvasBackground(CanvasBackground.WHITE);
+    assertEquals(CanvasBackground.WHITE, fx.app.getPreferences().getCanvasBackground());
   }
 
   @Test

--- a/src/test/java/io/github/compilerstuck/visual/gradient/ColorGradientTest.java
+++ b/src/test/java/io/github/compilerstuck/visual/gradient/ColorGradientTest.java
@@ -1,0 +1,43 @@
+package io.github.compilerstuck.visual.gradient;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import io.github.compilerstuck.control.config.AppConfig;
+import io.github.compilerstuck.visual.Marker;
+import java.awt.Color;
+import org.junit.jupiter.api.Test;
+
+class ColorGradientTest {
+
+  @Test
+  void whiteSetMarkerRemapsOnLightBackground() {
+    ColorGradient gradient = new ColorGradient(Color.RED, Color.BLUE, Color.WHITE, "test", 8);
+    assertEquals(Color.WHITE, gradient.getMarkerColor(0, Marker.SET));
+
+    Color dark =
+        new Color(
+            AppConfig.CANVAS_BACKGROUND_DARK,
+            AppConfig.CANVAS_BACKGROUND_DARK,
+            AppConfig.CANVAS_BACKGROUND_DARK);
+    gradient.setLightBackgroundMarkerOverride(dark);
+    assertEquals(dark, gradient.getMarkerColor(0, Marker.SET));
+
+    gradient.setLightBackgroundMarkerOverride(null);
+    assertEquals(Color.WHITE, gradient.getMarkerColor(0, Marker.SET));
+  }
+
+  @Test
+  void nonWhiteSetMarkerUnchangedOnLightBackground() {
+    ColorGradient gradient = new ColorGradient(Color.WHITE, Color.WHITE, Color.RED, "White", 8);
+    Color dark =
+        new Color(
+            AppConfig.CANVAS_BACKGROUND_DARK,
+            AppConfig.CANVAS_BACKGROUND_DARK,
+            AppConfig.CANVAS_BACKGROUND_DARK);
+    gradient.setLightBackgroundMarkerOverride(dark);
+    assertSame(Color.RED, gradient.getMarkerColor(0, Marker.SET));
+    assertNotEquals(dark, gradient.getMarkerColor(0, Marker.SET));
+  }
+}


### PR DESCRIPTION
## Summary
- Add an Appearance **Background** control (Dark `#0F0F0F` / White `#FFFFFF`) persisted via preferences
- Clear the canvas and results table from the chosen background; remap opaque-white `Marker.SET` colors to dark on white
- Flip HUD/results overlay text contrast so light backgrounds stay readable

## Test plan
- [ ] Open Settings → Appearance; switch Background between Dark and White and confirm the canvas clear color updates immediately
- [ ] Run a sort with a preset that uses white SET markers (e.g. Black → Red); on White background, active markers should appear dark (`#0F0F0F`)
- [ ] Confirm HUD / measurements text is dark on white and white on dark
- [ ] Enable comparison table; verify results overlay matches the chosen background and text contrast
- [ ] Restart the app and confirm the Background choice is restored