### PR TITLE
feat: equalize prepare HUD, delay stride, and skip algorithm

### DIFF
--- a/src/main/java/io/github/compilerstuck/control/AppContext.java
+++ b/src/main/java/io/github/compilerstuck/control/AppContext.java
@@ -335,6 +335,11 @@ public final class AppContext {
     sessionManager.cancel();
   }
 
+  /** Skips the current algorithm during a multi-algorithm session; continues with the next. */
+  public void skipCurrentAlgorithm() {
+    sessionManager.skipCurrent();
+  }
+
   public void setAlgorithms(List<SortingAlgorithm> algorithmList) {
     algorithms.clear();
     for (SortingAlgorithm alg : algorithmList) {

--- a/src/main/java/io/github/compilerstuck/control/SortingVisualizerGame.java
+++ b/src/main/java/io/github/compilerstuck/control/SortingVisualizerGame.java
@@ -235,7 +235,7 @@ public final class SortingVisualizerGame extends Game {
 
     sound.cutNotes();
 
-    sessionManager.printTimestampsToConsole(new ArrayList<>(currentAlgorithms()));
+    sessionManager.printTimestampsToConsole(sessionManager.getCompletedAlgorithms());
     arrayController.resetMeasurements();
     stateManager.setCurrentOperation("Waiting");
 

--- a/src/main/java/io/github/compilerstuck/control/model/EqualizePacing.java
+++ b/src/main/java/io/github/compilerstuck/control/model/EqualizePacing.java
@@ -105,6 +105,19 @@ public final class EqualizePacing {
    * @param arrayLength used to cap batched {@code delayFrame} beats per draw frame on large arrays
    */
   public void begin(int totalSteps, int frameBeats, float sliderTargetSec, int arrayLength) {
+    begin(totalSteps, frameBeats, sliderTargetSec, arrayLength, 0);
+  }
+
+  /**
+   * @param maxStepsPerFrameOverride when {@code > 0}, caps grants per frame (e.g. {@code 1} for
+   *     strided {@code delay()} algorithms so {@code awaitIdle} cannot stall on leftover credits)
+   */
+  public void begin(
+      int totalSteps,
+      int frameBeats,
+      float sliderTargetSec,
+      int arrayLength,
+      int maxStepsPerFrameOverride) {
     if (totalSteps <= 0) {
       clear();
       return;
@@ -112,10 +125,14 @@ public final class EqualizePacing {
     this.totalSteps = totalSteps;
     this.frameBeats = Math.max(0, frameBeats);
     this.sliderTargetSec = Math.max(0f, sliderTargetSec);
-    this.maxStepsPerFrame =
-        this.frameBeats > 0
-            ? AppConfig.equalizeMaxFrameBeatsPerFrame(arrayLength)
-            : AppConfig.EQUALIZE_MAX_STEPS_PER_FRAME;
+    if (maxStepsPerFrameOverride > 0) {
+      this.maxStepsPerFrame = maxStepsPerFrameOverride;
+    } else {
+      this.maxStepsPerFrame =
+          this.frameBeats > 0
+              ? AppConfig.equalizeMaxFrameBeatsPerFrame(arrayLength)
+              : AppConfig.EQUALIZE_MAX_STEPS_PER_FRAME;
+    }
     this.stepsConsumed.set(0);
     this.frameBeatsConsumed.set(0);
     this.frameWaitDebt = 0d;
@@ -158,7 +175,9 @@ public final class EqualizePacing {
     }
     int remainingSteps = Math.max(0, totalSteps - stepsConsumed.get());
     if (remainingSteps == 0) {
-      return 1;
+      // Budget exhausted but the worker may still be awaiting (underestimated step count /
+      // delay stride). Sprint at the per-frame cap instead of dripping 1 credit/frame.
+      return maxStepsPerFrame;
     }
     float elapsedSec = (System.nanoTime() - startNanos) / 1_000_000_000f;
     float remainingTime = Math.max(MIN_REMAINING_SEC, sliderTargetSec - elapsedSec);

--- a/src/main/java/io/github/compilerstuck/control/model/SortingSessionManager.java
+++ b/src/main/java/io/github/compilerstuck/control/model/SortingSessionManager.java
@@ -3,6 +3,7 @@ package io.github.compilerstuck.control.model;
 import io.github.compilerstuck.control.config.AppConfig;
 import io.github.compilerstuck.control.render.CountingDelayContext;
 import io.github.compilerstuck.control.render.DelayContext;
+import io.github.compilerstuck.control.render.PrepareProgressDelayContext;
 import io.github.compilerstuck.control.render.TrackingDelayContext;
 import io.github.compilerstuck.control.ui.TimeEstimateFormat;
 import io.github.compilerstuck.sortingalgorithms.BogoSort;
@@ -43,6 +44,7 @@ public class SortingSessionManager {
   private final List<String> writesMain = new ArrayList<>();
   private final List<String> writesAux = new ArrayList<>();
   private final List<Integer> timestamps = new ArrayList<>();
+  private final List<SortingAlgorithm> completedAlgorithms = new ArrayList<>();
 
   private Thread executionThread;
   private volatile CancellationToken cancellationToken = CancellationToken.alwaysActive();
@@ -110,16 +112,12 @@ public class SortingSessionManager {
     // Clear previous results
     clearMeasurements();
 
-    CancellationToken token = new CancellationToken();
-    this.cancellationToken = token;
     stateManager.setContinueExecution(true);
 
     OperationReporter reporter = stateManager::setCurrentOperation;
-    arrayController.setCancellationToken(token);
     arrayController.setOperationReporter(reporter);
 
     for (SortingAlgorithm algorithm : algorithms) {
-      algorithm.setCancellationToken(token);
       algorithm.setOperationReporter(reporter);
     }
 
@@ -134,6 +132,18 @@ public class SortingSessionManager {
     stateManager.setContinueExecution(false);
   }
 
+  /**
+   * Aborts the current algorithm so the session can continue with the next one. Does not end the
+   * session; call {@link #cancel()} to stop entirely.
+   */
+  public void skipCurrent() {
+    cancellationToken.cancel();
+    FrameGate gate = frameGate;
+    if (gate != null) {
+      gate.cancel();
+    }
+  }
+
   CancellationToken getCancellationToken() {
     return cancellationToken;
   }
@@ -144,26 +154,43 @@ public class SortingSessionManager {
       int startTime = (int) (System.currentTimeMillis() / 1000L);
 
       for (SortingAlgorithm algorithm : algorithms) {
-        if (!stateManager.shouldContinueExecution() || cancellationToken.isCancelled()) {
+        if (!stateManager.shouldContinueExecution()) {
           LOGGER.log(Level.INFO, "Sorting session cancelled by user");
           break;
         }
 
-        recordTimestamp(startTime);
+        armAlgorithmToken(algorithm);
         prepareForAlgorithm();
-        executeAlgorithm(algorithm);
 
-        if (!stateManager.shouldContinueExecution() || cancellationToken.isCancelled()) {
+        if (!stateManager.shouldContinueExecution()) {
+          LOGGER.log(Level.INFO, "Sorting session cancelled by user");
           break;
         }
+        if (cancellationToken.isCancelled()) {
+          LOGGER.log(Level.INFO, "Skipped algorithm during prepare: {0}", algorithm.getName());
+          continue;
+        }
 
+        executeAlgorithm(algorithm);
+
+        if (!stateManager.shouldContinueExecution()) {
+          LOGGER.log(Level.INFO, "Sorting session cancelled by user");
+          break;
+        }
+        if (cancellationToken.isCancelled()) {
+          LOGGER.log(Level.INFO, "Skipped algorithm: {0}", algorithm.getName());
+          continue;
+        }
+
+        recordTimestamp(startTime);
         recordMeasurements();
+        completedAlgorithms.add(algorithm);
         pauseAfterAlgorithm();
       }
 
       if (stateManager.shouldContinueExecution()
-          && !cancellationToken.isCancelled()
-          && stateManager.shouldShowComparisonTable()) {
+          && stateManager.shouldShowComparisonTable()
+          && !completedAlgorithms.isEmpty()) {
         stateManager.setShowResults(true);
       }
 
@@ -180,6 +207,18 @@ public class SortingSessionManager {
         gate.drain();
       }
       stateManager.setRunning(false);
+    }
+  }
+
+  /** Fresh per-algorithm cancel token and FrameGate so a prior skip does not abort the next. */
+  private void armAlgorithmToken(SortingAlgorithm algorithm) {
+    CancellationToken token = new CancellationToken();
+    this.cancellationToken = token;
+    arrayController.setCancellationToken(token);
+    algorithm.setCancellationToken(token);
+    FrameGate gate = frameGate;
+    if (gate != null) {
+      gate.reset();
     }
   }
 
@@ -219,6 +258,7 @@ public class SortingSessionManager {
               /* no-op */
             };
     try {
+      algorithm.setDelayStride(1);
       if (tryArmEqualizePacing(algorithm, fallback)) {
         algorithm.setDelayContext(
             new TrackingDelayContext(fallback, stateManager.equalizePacing()));
@@ -226,6 +266,7 @@ public class SortingSessionManager {
         if (algorithm instanceof GravitySort gravity) {
           gravity.setColumnStride(1);
         }
+        algorithm.setDelayStride(1);
         algorithm.setDelayContext(fallback);
       }
 
@@ -240,12 +281,20 @@ public class SortingSessionManager {
       if (algorithm instanceof GravitySort gravity) {
         gravity.setColumnStride(1);
       }
+      algorithm.setDelayStride(1);
       algorithm.setDelayContext(fallback);
+      // Drop unused equalize credits so awaitIdle cannot stall after a short/strided run.
+      FrameGate gate = frameGate;
+      if (gate != null) {
+        gate.drain();
+      }
     }
   }
 
   /**
    * Silent dry-run that counts visual steps, restores the array, and arms {@link EqualizePacing}.
+   * When the counted (or estimated) step total exceeds the equalize frame budget, a delay stride is
+   * applied so the visual pass can still hit the slider target.
    *
    * @return true when equalize pacing was armed for the visual pass
    */
@@ -283,35 +332,52 @@ public class SortingSessionManager {
           Level.INFO,
           "Gravity equalize stride={0} (naturalBeats={1}, budget={2}, visualBeats={3})",
           new Object[] {stride, naturalBeats, budget, visualBeats});
-      return armEqualize(algorithm.getName(), visualBeats, visualBeats, sliderTarget);
+      return armEqualize(algorithm.getName(), visualBeats, visualBeats, sliderTarget, 0);
     }
 
     int[] snapshot = Arrays.copyOf(arrayController.getArray(), arrayController.getLength());
     OperationReporter previousReporter = stateManager::setCurrentOperation;
     CancellationToken dryToken = new CancellationToken();
     CancellationToken sessionToken = cancellationToken;
+    long prepareStartNanos = System.nanoTime();
+    long prepareTimeoutNanos = TimeUnit.MILLISECONDS.toNanos(AppConfig.EQUALIZE_DRY_RUN_TIMEOUT_MS);
     CountingDelayContext counter =
         new CountingDelayContext(
-            System.nanoTime()
-                + TimeUnit.MILLISECONDS.toNanos(AppConfig.EQUALIZE_DRY_RUN_TIMEOUT_MS),
-            sessionToken::isCancelled,
-            dryToken::cancel);
+            prepareStartNanos + prepareTimeoutNanos, sessionToken::isCancelled, dryToken::cancel);
+    PrepareProgressDelayContext progressCounter =
+        new PrepareProgressDelayContext(
+            counter,
+            prepareStartNanos,
+            prepareTimeoutNanos,
+            stateManager::setCurrentOperation,
+            stateManager::setEqualizePrepareProgress);
 
-    stateManager.setCurrentOperation("Preparing…");
+    algorithm.setDelayStride(1);
     // Render must not grant FrameGate credits during the dry-run (nothing consumes them).
     stateManager.setFrameGateSuspended(true);
+    stateManager.setEqualizePreparing(true);
     FrameGate gate = frameGate;
     if (gate != null) {
       gate.drain();
     }
 
-    algorithm.setDelayContext(counter);
+    algorithm.setDelayContext(progressCounter);
     algorithm.setOperationReporter(OperationReporter.NOOP);
     algorithm.setCancellationToken(dryToken);
 
+    long partialSteps = 0L;
+    long partialFrameBeats = 0L;
+    double progressSample = 0d;
     try {
       sound.withMuted(algorithm::sort);
+      progressCounter.complete();
     } finally {
+      // Sample progress before restore so timeout extrapolation sees dry-run work.
+      partialSteps = counter.stepCount();
+      partialFrameBeats = counter.frameBeatCount();
+      arrayController.update();
+      progressSample = arrayController.getSortedPercentage();
+
       algorithm.endTiming();
       algorithm.setCancellationToken(sessionToken);
       algorithm.setOperationReporter(previousReporter);
@@ -321,37 +387,134 @@ public class SortingSessionManager {
       if (gate != null) {
         gate.drain();
       }
+      stateManager.setEqualizePreparing(false);
       stateManager.setFrameGateSuspended(false);
     }
 
     if (sessionToken.isCancelled() || !stateManager.shouldContinueExecution()) {
       return false;
     }
+    if (counter.aborted()) {
+      return false;
+    }
+
+    int n = arrayController.getLength();
+    long rawSteps = estimateRawSteps(counter.timedOut(), partialSteps, progressSample, n);
+    if (rawSteps <= 0) {
+      return false;
+    }
+
+    DelayStridePlan plan = planDelayStride(rawSteps, sliderTarget);
+    int stride = plan.stride();
+    int visualSteps = plan.visualSteps();
+
+    long rawFrameBeats = partialFrameBeats;
+    if (counter.timedOut() && partialFrameBeats > 0L && partialSteps > 0L) {
+      // Scale frame-beat estimate in the same proportion as steps when extrapolating.
+      rawFrameBeats =
+          Math.max(
+              partialFrameBeats,
+              Math.round(partialFrameBeats * ((double) rawSteps / (double) partialSteps)));
+    }
+    int visualFrameBeats = 0;
+    if (rawFrameBeats > 0L) {
+      visualFrameBeats = clampToInt(Math.max(1L, (rawFrameBeats + stride - 1L) / stride));
+    }
+
+    algorithm.setDelayStride(stride);
     if (counter.timedOut()) {
       LOGGER.log(
           Level.INFO,
-          "Equalize dry-run timed out for {0}; using normal speed pacing",
-          algorithm.getName());
-      return false;
-    }
-    if (counter.aborted() || dryToken.isCancelled()) {
-      return false;
-    }
-
-    int totalSteps = clampToInt(counter.stepCount());
-    int frameBeats = clampToInt(counter.frameBeatCount());
-    if (totalSteps <= 0) {
-      return false;
+          "Equalize dry-run timed out for {0}; estimated steps={1}, stride={2}, visualSteps={3}, maxSteps/frame={4}",
+          new Object[] {
+            algorithm.getName(), rawSteps, stride, visualSteps, plan.maxStepsPerFrame()
+          });
+    } else if (stride > 1) {
+      LOGGER.log(
+          Level.INFO,
+          "Equalize stride={0} for {1} (rawSteps={2}, frameBudget={3}, visualSteps={4})",
+          new Object[] {stride, algorithm.getName(), rawSteps, plan.budget(), visualSteps});
     }
 
-    return armEqualize(algorithm.getName(), totalSteps, frameBeats, sliderTarget);
+    return armEqualize(
+        algorithm.getName(), visualSteps, visualFrameBeats, sliderTarget, plan.maxStepsPerFrame());
+  }
+
+  /**
+   * Chooses delay stride so equalize can hit {@code sliderTarget}.
+   *
+   * <ul>
+   *   <li>If {@code rawSteps} fits in {@code EQUALIZE_MAX_STEPS_PER_FRAME × 60 × target}, stride is
+   *       1 and multi-credit frames are used.
+   *   <li>Otherwise stride is {@code ceil(rawSteps / (60 × target))} (one visual beat per frame)
+   *       and grants are capped at 1 so {@code awaitIdle} cannot stall on leftover credits.
+   * </ul>
+   */
+  static DelayStridePlan planDelayStride(long rawSteps, float sliderTarget) {
+    float target = Math.max(0.1f, sliderTarget);
+    long frameBudget =
+        Math.max(1L, Math.round((double) AppConfig.TARGET_FRAME_RATE * (double) target));
+    long highThroughputBudget = (long) AppConfig.EQUALIZE_MAX_STEPS_PER_FRAME * frameBudget;
+    if (rawSteps <= highThroughputBudget) {
+      return new DelayStridePlan(
+          1, clampToInt(rawSteps), AppConfig.EQUALIZE_MAX_STEPS_PER_FRAME, highThroughputBudget);
+    }
+    int stride = clampToInt(Math.max(1L, (rawSteps + frameBudget - 1L) / frameBudget));
+    int visualSteps = clampToInt(Math.max(1L, (rawSteps + (long) stride - 1L) / stride));
+    return new DelayStridePlan(stride, visualSteps, 1, frameBudget);
+  }
+
+  /** Result of {@link #planDelayStride(long, float)}. */
+  record DelayStridePlan(int stride, int visualSteps, int maxStepsPerFrame, long budget) {}
+
+  /**
+   * Raw delay count for equalize arming. Completed dry-runs keep the counted total.
+   *
+   * <p>On timeout:
+   *
+   * <ul>
+   *   <li>Swap-dense algorithms (Bubble/Shaker/Gnome) usually already counted {@code ≥ n} delays —
+   *       use the quadratic upper bound (sorted-% stays low while most swaps remain).
+   *   <li>Sparse-delay algorithms (Selection/Cycle/…) have {@code < n} delays — extrapolate from
+   *       sorted progress (floored at {@code n}) so we do not arm a Bubble-sized stride that skips
+   *       almost every real delay and stalls {@code FrameGate.awaitIdle}.
+   * </ul>
+   */
+  static long estimateRawSteps(boolean timedOut, long partialSteps, double progressSample, int n) {
+    if (!timedOut) {
+      return Math.max(0L, partialSteps);
+    }
+    long upper = maxSwapDelaysUpperBound(n);
+    if (partialSteps <= 0L) {
+      return upper;
+    }
+    if (n > 0 && partialSteps >= n) {
+      return upper;
+    }
+    // At least one element of progress so early Selection placements extrapolate toward ~n.
+    double progress = Math.max(progressSample, n > 0 ? 1.0d / n : 0.02d);
+    long extrapolated = Math.round(partialSteps / progress);
+    long atLeastN = Math.max(n, partialSteps);
+    return Math.min(Math.max(atLeastN, extrapolated), upper);
+  }
+
+  /** Conservative upper bound for delay-per-swap algorithms: {@code n*(n-1)/2}. */
+  static long maxSwapDelaysUpperBound(int n) {
+    if (n <= 1) {
+      return 1L;
+    }
+    return (long) n * (n - 1L) / 2L;
   }
 
   private boolean armEqualize(
-      String algorithmName, int totalSteps, int frameBeats, float sliderTarget) {
+      String algorithmName,
+      int totalSteps,
+      int frameBeats,
+      float sliderTarget,
+      int maxStepsPerFrame) {
     stateManager
         .equalizePacing()
-        .begin(totalSteps, frameBeats, sliderTarget, arrayController.getLength());
+        .begin(totalSteps, frameBeats, sliderTarget, arrayController.getLength(), maxStepsPerFrame);
     LOGGER.log(
         Level.INFO,
         "Equalize armed for {0}: steps={1}, frameBeats={2}, targetSec={3}, batch={4}, maxSteps/frame={5}",
@@ -424,6 +587,7 @@ public class SortingSessionManager {
     writesMain.clear();
     writesAux.clear();
     timestamps.clear();
+    completedAlgorithms.clear();
   }
 
   /** Waits for the current sorting session to complete. */
@@ -457,6 +621,11 @@ public class SortingSessionManager {
 
   public List<String> getWritesAux() {
     return new ArrayList<>(writesAux);
+  }
+
+  /** Algorithms that finished (not skipped or cancelled) in this session, in run order. */
+  public List<SortingAlgorithm> getCompletedAlgorithms() {
+    return new ArrayList<>(completedAlgorithms);
   }
 
   /** Logs timing information to console after sorting completes. */

--- a/src/main/java/io/github/compilerstuck/control/model/SortingStateManager.java
+++ b/src/main/java/io/github/compilerstuck/control/model/SortingStateManager.java
@@ -1,6 +1,7 @@
 package io.github.compilerstuck.control.model;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Thread-safe state manager for sorting visualization. Encapsulates all mutable state that is
@@ -21,6 +22,15 @@ public class SortingStateManager {
    * draw without granting FrameGate credits; the worker is not consuming steps.
    */
   private final AtomicBoolean frameGateSuspended = new AtomicBoolean(false);
+
+  /**
+   * True during the equalize dry-run. Render must draw the last published snapshot without
+   * republishing live mutations (avoids a fast-sort flash before restore).
+   */
+  private final AtomicBoolean equalizePreparing = new AtomicBoolean(false);
+
+  /** 0–100 progress for the equalize Prepare.. phase (settings bar + tests). */
+  private final AtomicInteger equalizePrepareProgress = new AtomicInteger(0);
 
   private final EqualizePacing equalizePacing = new EqualizePacing();
 
@@ -111,6 +121,27 @@ public class SortingStateManager {
     frameGateSuspended.set(value);
   }
 
+  /** True while equalize is counting visual steps on the live array. */
+  public boolean isEqualizePreparing() {
+    return equalizePreparing.get();
+  }
+
+  public void setEqualizePreparing(boolean value) {
+    equalizePreparing.set(value);
+    if (!value) {
+      equalizePrepareProgress.set(0);
+    }
+  }
+
+  /** Progress percent for the Prepare.. dry-run (0–100). */
+  public int getEqualizePrepareProgress() {
+    return equalizePrepareProgress.get();
+  }
+
+  public void setEqualizePrepareProgress(int percent) {
+    equalizePrepareProgress.set(Math.max(0, Math.min(100, percent)));
+  }
+
   /** Equalize-sort-duration pacing for the active algorithm (inactive when mode is off). */
   public EqualizePacing equalizePacing() {
     return equalizePacing;
@@ -132,6 +163,8 @@ public class SortingStateManager {
     shouldRestart.set(false);
     shuffling.set(false);
     frameGateSuspended.set(false);
+    equalizePreparing.set(false);
+    equalizePrepareProgress.set(0);
     equalizePacing.clear();
     currentOperation = "Waiting";
   }

--- a/src/main/java/io/github/compilerstuck/control/render/HudRenderer.java
+++ b/src/main/java/io/github/compilerstuck/control/render/HudRenderer.java
@@ -24,6 +24,7 @@ public final class HudRenderer {
   private long cachedWritesAux = Long.MIN_VALUE;
   private int cachedLength = Integer.MIN_VALUE;
   private String cachedRealTimeFormatted;
+  private boolean cachedPreparing;
   private int cachedLayoutWidth = Integer.MIN_VALUE;
   private int cachedTextX;
   private int cachedTextSize;
@@ -96,6 +97,7 @@ public final class HudRenderer {
     cachedWritesAux = m.writesAux;
     cachedLength = m.length;
     cachedRealTimeFormatted = m.realTime;
+    cachedPreparing = m.preparing;
 
     labels[0] = m.operation;
     labels[1] = buildSortedLine(m.sortedPct, m.segments);
@@ -108,8 +110,38 @@ public final class HudRenderer {
     labelsInitialized = true;
   }
 
-  private static Metrics readMetrics(
-      SortingStateManager stateManager, ArrayController arrayController) {
+  private Metrics readMetrics(SortingStateManager stateManager, ArrayController arrayController) {
+    int length = arrayController.getLength();
+    if (stateManager.isEqualizePreparing()) {
+      // Keep end-of-shuffle numbers; only the operation line switches to Prepare..
+      if (labelsInitialized) {
+        return new Metrics(
+            stateManager.getCurrentOperation(),
+            cachedSortedPct,
+            cachedSegments,
+            cachedComparisons,
+            cachedSwaps,
+            cachedWrites,
+            cachedWritesAux,
+            length,
+            cachedRealTimeFormatted != null
+                ? cachedRealTimeFormatted
+                : TimeEstimateFormat.format(0),
+            true);
+      }
+      // No prior HUD frame (tests / first draw): show zeros, never live dry-run counters.
+      return new Metrics(
+          stateManager.getCurrentOperation(),
+          0,
+          0,
+          0L,
+          0L,
+          0L,
+          0L,
+          length,
+          TimeEstimateFormat.format(0),
+          true);
+    }
     return new Metrics(
         stateManager.getCurrentOperation(),
         (int) (arrayController.getSortedPercentage() * 100),
@@ -118,12 +150,14 @@ public final class HudRenderer {
         arrayController.getSwaps(),
         arrayController.getWrites(),
         arrayController.getWritesAux(),
-        arrayController.getLength(),
-        TimeEstimateFormat.format(arrayController.getRealTime()));
+        length,
+        TimeEstimateFormat.format(arrayController.getRealTime()),
+        false);
   }
 
   private boolean sameKeys(Metrics m) {
-    return m.sortedPct == cachedSortedPct
+    return m.preparing == cachedPreparing
+        && m.sortedPct == cachedSortedPct
         && m.segments == cachedSegments
         && m.comparisons == cachedComparisons
         && m.swaps == cachedSwaps
@@ -161,5 +195,6 @@ public final class HudRenderer {
       long writes,
       long writesAux,
       int length,
-      String realTime) {}
+      String realTime,
+      boolean preparing) {}
 }

--- a/src/main/java/io/github/compilerstuck/control/render/PrepareProgressDelayContext.java
+++ b/src/main/java/io/github/compilerstuck/control/render/PrepareProgressDelayContext.java
@@ -1,0 +1,78 @@
+package io.github.compilerstuck.control.render;
+
+import io.github.compilerstuck.control.model.OperationReporter;
+import java.util.Objects;
+import java.util.function.IntConsumer;
+
+/**
+ * Counts dry-run delays like {@link CountingDelayContext} while reporting time-based Prepare..
+ * progress (same HUD style as {@code Shuffling.. N%}).
+ */
+public final class PrepareProgressDelayContext implements DelayContext {
+  /** Minimum gap between HUD / progress-bar updates during a fast dry-run. */
+  static final long REPORT_INTERVAL_NANOS = 50_000_000L; // 50ms
+
+  private final CountingDelayContext counter;
+  private final long startNanos;
+  private final long timeoutNanos;
+  private final OperationReporter reporter;
+  private final IntConsumer progressSink;
+  private long lastReportNanos;
+  private int lastReportedPct = -1;
+
+  public PrepareProgressDelayContext(
+      CountingDelayContext counter,
+      long startNanos,
+      long timeoutNanos,
+      OperationReporter reporter,
+      IntConsumer progressSink) {
+    this.counter = Objects.requireNonNull(counter, "counter");
+    this.startNanos = startNanos;
+    this.timeoutNanos = Math.max(1L, timeoutNanos);
+    this.reporter = reporter != null ? reporter : OperationReporter.NOOP;
+    this.progressSink = progressSink != null ? progressSink : pct -> {};
+    this.lastReportNanos = startNanos;
+    report(0);
+  }
+
+  @Override
+  public void delay() {
+    counter.delay();
+    maybeReport();
+  }
+
+  @Override
+  public void delayFrame() {
+    counter.delayFrame();
+    maybeReport();
+  }
+
+  /** Forces a final 100% report when the dry-run finishes before the timeout. */
+  public void complete() {
+    report(100);
+  }
+
+  public CountingDelayContext counter() {
+    return counter;
+  }
+
+  private void maybeReport() {
+    long now = System.nanoTime();
+    if (now - lastReportNanos < REPORT_INTERVAL_NANOS) {
+      return;
+    }
+    lastReportNanos = now;
+    long elapsed = Math.max(0L, now - startNanos);
+    int pct = (int) Math.min(99L, (elapsed * 100L) / timeoutNanos);
+    report(pct);
+  }
+
+  private void report(int pct) {
+    if (pct == lastReportedPct) {
+      return;
+    }
+    lastReportedPct = pct;
+    reporter.report("Prepare.. " + pct + "%");
+    progressSink.accept(pct);
+  }
+}

--- a/src/main/java/io/github/compilerstuck/control/screen/ResultsScreen.java
+++ b/src/main/java/io/github/compilerstuck/control/screen/ResultsScreen.java
@@ -84,7 +84,7 @@ public final class ResultsScreen implements Screen {
         resultsTableRenderer.render(
             renderSystem,
             background,
-            game.currentAlgorithms(),
+            game.sessionManager().getCompletedAlgorithms(),
             game.sessionManager().getComparisons(),
             game.sessionManager().getRealTime(),
             game.sessionManager().getSwaps(),

--- a/src/main/java/io/github/compilerstuck/control/screen/VisualizerScreen.java
+++ b/src/main/java/io/github/compilerstuck/control/screen/VisualizerScreen.java
@@ -75,7 +75,11 @@ public final class VisualizerScreen implements Screen {
         game.finishSession(true);
         game.publishThenDraw(frameDelta);
       } else if (stateManager.isRunning()) {
-        if (stateManager.isFrameGateSuspended()) {
+        if (stateManager.isEqualizePreparing()) {
+          // Dry-run mutates the live array; keep the last published (shuffled) snapshot on screen.
+          game.drawWorld(frameDelta);
+          publishProgressIfDue(frameDelta, stateManager.getEqualizePrepareProgress());
+        } else if (stateManager.isFrameGateSuspended()) {
           // Worker is in a timed pause (not consuming credits); keep animating without pacing.
           game.publishThenDraw(frameDelta);
         } else {

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/RunAllOrderDialog.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/RunAllOrderDialog.java
@@ -3,13 +3,18 @@ package io.github.compilerstuck.control.ui.settingsfx;
 import atlantafx.base.theme.Styles;
 import io.github.compilerstuck.control.ui.settingsfx.vm.AlgorithmEntry;
 import io.github.compilerstuck.control.ui.settingsfx.vm.AlgorithmViewModel;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.control.Alert;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonBar;
 import javafx.scene.control.ButtonType;
@@ -30,14 +35,22 @@ import javafx.scene.layout.VBox;
 import javafx.stage.Window;
 
 /**
- * Modal dialog to include/exclude run-all algorithms and drag-reorder them.
+ * Modal dialog to include/exclude algorithms and drag-reorder them for the dropdown and Run all.
  *
  * <p>Layout: hint → selection summary + bulk actions → numbered reorderable list → Cancel / Apply.
+ * Closing with unsaved changes offers save, discard, or keep editing (same pattern as customize).
  */
 public final class RunAllOrderDialog {
 
   public static final String DIALOG_ID = "run-all-order-dialog";
   public static final String LIST_ID = "run-all-order-list";
+  public static final String DISCARD_CONFIRM_ID = "run-all-order-discard-confirm";
+
+  private enum UnsavedCloseChoice {
+    SAVE,
+    DISCARD,
+    CANCEL
+  }
 
   private RunAllOrderDialog() {}
 
@@ -46,6 +59,8 @@ public final class RunAllOrderDialog {
     for (AlgorithmEntry entry : vm.getEntries()) {
       rows.add(new DraftRow(entry.getId(), entry.getName(), entry.isSelected()));
     }
+    List<BaselineRow> baseline = snapshotBaseline(rows);
+    AtomicBoolean closingConfirmed = new AtomicBoolean(false);
 
     Label hint = new Label(SettingsStrings.RUN_ALL_ORDER_HINT);
     hint.getStyleClass().add("settings-muted");
@@ -136,29 +151,172 @@ public final class RunAllOrderDialog {
           if (selectedCount(rows) == 0) {
             e.consume();
             showStatus(status, SettingsStrings.RUN_ALL_ORDER_EMPTY, true);
+          } else {
+            // Avoid a second unsaved prompt if window close also fires on Apply.
+            closingConfirmed.set(true);
           }
         });
 
     Button cancelButton = (Button) dialog.getDialogPane().lookupButton(cancelType);
     cancelButton.getStyleClass().add(Styles.BUTTON_OUTLINED);
+    cancelButton.addEventFilter(
+        javafx.event.ActionEvent.ACTION,
+        e -> {
+          if (closingConfirmed.get()) {
+            return;
+          }
+          if (!confirmCloseIfDirty(vm, rows, baseline, status, dialog)) {
+            e.consume();
+          } else {
+            closingConfirmed.set(true);
+          }
+        });
 
     var css = SettingsStylesheets.cssUrl();
     if (css != null) {
       dialog.getDialogPane().getStylesheets().add(css.toExternalForm());
     }
 
-    dialog
+    // Window close (X): same dirty confirmation as Cancel.
+    dialog.setOnShown(
+        e -> {
+          Window window = dialog.getDialogPane().getScene().getWindow();
+          if (window == null) {
+            return;
+          }
+          window.setOnCloseRequest(
+              closeEvent -> {
+                if (closingConfirmed.get()) {
+                  return;
+                }
+                if (!confirmCloseIfDirty(vm, rows, baseline, status, dialog)) {
+                  closeEvent.consume();
+                } else {
+                  closingConfirmed.set(true);
+                }
+              });
+        });
+
+    dialog.showAndWait().filter(applyType::equals).ifPresent(ignored -> applyDraft(vm, rows));
+  }
+
+  /**
+   * @return {@code true} if the dialog may close (clean, saved, or discarded)
+   */
+  private static boolean confirmCloseIfDirty(
+      AlgorithmViewModel vm,
+      ObservableList<DraftRow> rows,
+      List<BaselineRow> baseline,
+      Label status,
+      Dialog<?> dialog) {
+    if (!isDirty(rows, baseline)) {
+      return true;
+    }
+    UnsavedCloseChoice choice =
+        askUnsavedCloseChoice(dialog.getDialogPane().getScene().getWindow());
+    return switch (choice) {
+      case SAVE -> {
+        if (selectedCount(rows) == 0) {
+          showStatus(status, SettingsStrings.RUN_ALL_ORDER_EMPTY, true);
+          yield false;
+        }
+        applyDraft(vm, rows);
+        yield true;
+      }
+      case DISCARD -> true;
+      case CANCEL -> false;
+    };
+  }
+
+  private static void applyDraft(AlgorithmViewModel vm, ObservableList<DraftRow> rows) {
+    Set<String> selected =
+        rows.stream()
+            .filter(r -> r.selected)
+            .map(r -> r.id)
+            .collect(Collectors.toCollection(HashSet::new));
+    vm.applyRunAllOrder(rows.stream().map(r -> r.id).toList(), selected);
+  }
+
+  /** Package-visible for unit tests. */
+  static boolean isDirty(List<DraftRow> rows, List<BaselineRow> baseline) {
+    if (rows.size() != baseline.size()) {
+      return true;
+    }
+    for (int i = 0; i < rows.size(); i++) {
+      DraftRow row = rows.get(i);
+      BaselineRow expected = baseline.get(i);
+      if (!row.id.equals(expected.id()) || row.selected != expected.selected()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static List<BaselineRow> snapshotBaseline(List<DraftRow> rows) {
+    List<BaselineRow> baseline = new ArrayList<>(rows.size());
+    for (DraftRow row : rows) {
+      baseline.add(new BaselineRow(row.id, row.selected));
+    }
+    return List.copyOf(baseline);
+  }
+
+  /**
+   * Unsaved-close layout (same as customize):
+   *
+   * <pre>
+   * [Discard changes]              [Keep editing]  [Save and close]
+   * </pre>
+   */
+  private static UnsavedCloseChoice askUnsavedCloseChoice(Window owner) {
+    Alert alert = new Alert(Alert.AlertType.CONFIRMATION);
+    alert.initOwner(owner);
+    alert.setTitle(SettingsStrings.CUSTOMIZE_UNSAVED_TITLE);
+    alert.setHeaderText(null);
+    alert.setContentText(SettingsStrings.RUN_ALL_ORDER_UNSAVED_MESSAGE);
+    alert.getDialogPane().setId(DISCARD_CONFIRM_ID);
+
+    ButtonType discard =
+        new ButtonType(SettingsStrings.CUSTOMIZE_DISCARD, ButtonBar.ButtonData.LEFT);
+    ButtonType keepEditing =
+        new ButtonType(SettingsStrings.CUSTOMIZE_KEEP_EDITING, ButtonBar.ButtonData.CANCEL_CLOSE);
+    ButtonType saveAndClose =
+        new ButtonType(SettingsStrings.CUSTOMIZE_SAVE_AND_CLOSE, ButtonBar.ButtonData.OK_DONE);
+    alert.getButtonTypes().setAll(discard, keepEditing, saveAndClose);
+
+    var css = SettingsStylesheets.cssUrl();
+    if (css != null) {
+      alert.getDialogPane().getStylesheets().add(css.toExternalForm());
+    }
+
+    alert.setOnShown(
+        e -> {
+          Node barNode = alert.getDialogPane().lookup(".button-bar");
+          if (barNode instanceof ButtonBar bar) {
+            bar.setButtonOrder("L+CO");
+          }
+          Button saveButton = (Button) alert.getDialogPane().lookupButton(saveAndClose);
+          if (saveButton != null) {
+            saveButton.getStyleClass().add(Styles.ACCENT);
+          }
+          Button discardButton = (Button) alert.getDialogPane().lookupButton(discard);
+          if (discardButton != null) {
+            discardButton.getStyleClass().add(Styles.BUTTON_OUTLINED);
+          }
+        });
+
+    return alert
         .showAndWait()
-        .filter(applyType::equals)
-        .ifPresent(
-            ignored -> {
-              Set<String> selected =
-                  rows.stream()
-                      .filter(r -> r.selected)
-                      .map(r -> r.id)
-                      .collect(Collectors.toCollection(HashSet::new));
-              vm.applyRunAllOrder(rows.stream().map(r -> r.id).toList(), selected);
-            });
+        .map(
+            type -> {
+              if (saveAndClose.equals(type)) {
+                return UnsavedCloseChoice.SAVE;
+              }
+              if (discard.equals(type)) {
+                return UnsavedCloseChoice.DISCARD;
+              }
+              return UnsavedCloseChoice.CANCEL;
+            })
+        .orElse(UnsavedCloseChoice.CANCEL);
   }
 
   private static void refreshChrome(ObservableList<DraftRow> rows, Label countLabel, Label status) {
@@ -197,7 +355,11 @@ public final class RunAllOrderDialog {
     status.setManaged(false);
   }
 
-  private static final class DraftRow {
+  /** Package-visible for unit tests. */
+  record BaselineRow(String id, boolean selected) {}
+
+  /** Package-visible for unit tests. */
+  static final class DraftRow {
     final String id;
     final String name;
     boolean selected;

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SettingsFxController.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SettingsFxController.java
@@ -24,6 +24,7 @@ import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.ProgressBar;
+import javafx.scene.control.Tooltip;
 import javafx.scene.image.Image;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Screen;
@@ -49,6 +50,10 @@ public final class SettingsFxController implements SettingsBridge {
   private ProgressBar progressBar;
   private Button runButton;
   private Button cancelButton;
+  private Button skipButton;
+  private StackPane skipHost;
+  private Tooltip skipDisabledTip;
+  private boolean cancelEnabled;
   private boolean contentReady;
 
   private SoundViewModel soundVm;
@@ -130,9 +135,11 @@ public final class SettingsFxController implements SettingsBridge {
   public void setCancelEnabled(boolean enabled) {
     Platform.runLater(
         () -> {
+          cancelEnabled = enabled;
           if (cancelButton != null) {
             cancelButton.setDisable(!enabled);
           }
+          syncSkipEnabled();
         });
   }
 
@@ -241,8 +248,16 @@ public final class SettingsFxController implements SettingsBridge {
     progressBar = shell.progress();
     runButton = shell.run();
     cancelButton = shell.cancel();
+    skipButton = shell.skip();
+    if (skipButton.getParent() instanceof StackPane host) {
+      skipHost = host;
+      skipDisabledTip = SettingsControls.disabledTooltip();
+      SettingsControls.setDisabledTooltip(
+          skipHost, skipDisabledTip, SettingsStrings.SKIP_UNAVAILABLE_TOOLTIP);
+    }
     wireActionBar();
     updateRunEnabled();
+    syncSkipEnabled();
 
     Scene scene = new Scene(shell.root());
     applyAppStylesheet(scene);
@@ -303,7 +318,13 @@ public final class SettingsFxController implements SettingsBridge {
           if (AlgorithmViewModel.PROP_CAN_START.equals(evt.getPropertyName())
               || AlgorithmViewModel.PROP_RUN_ALL.equals(evt.getPropertyName())
               || AlgorithmViewModel.PROP_ENTRIES.equals(evt.getPropertyName())) {
-            VmBindings.runFx(this::updateRunEnabled);
+            VmBindings.runFx(
+                () -> {
+                  updateRunEnabled();
+                  if (AlgorithmViewModel.PROP_RUN_ALL.equals(evt.getPropertyName())) {
+                    syncSkipEnabled();
+                  }
+                });
           }
         });
   }
@@ -315,13 +336,18 @@ public final class SettingsFxController implements SettingsBridge {
           arraySizeVm.applyText();
           algorithmVm.applySelectionToAppContext();
           app.setStart(true);
+          cancelEnabled = true;
           cancelButton.setDisable(false);
+          syncSkipEnabled();
         });
     cancelButton.setOnAction(
         e -> {
           app.cancelSorting();
+          cancelEnabled = false;
           cancelButton.setDisable(true);
+          syncSkipEnabled();
         });
+    skipButton.setOnAction(e -> app.skipCurrentAlgorithm());
   }
 
   private void updateRunEnabled() {
@@ -330,5 +356,25 @@ public final class SettingsFxController implements SettingsBridge {
     }
     boolean enabled = inputsEnabled && arraySizeVm.canRun() && algorithmVm.canStart();
     runButton.setDisable(!enabled);
+  }
+
+  private void syncSkipEnabled() {
+    if (skipButton == null) {
+      return;
+    }
+    boolean enabled = cancelEnabled && algorithmVm != null && algorithmVm.isRunAll();
+    skipButton.setDisable(!enabled);
+    if (enabled) {
+      if (skipHost != null && skipDisabledTip != null) {
+        SettingsControls.setDisabledTooltip(skipHost, skipDisabledTip, null);
+      }
+      skipButton.setTooltip(new Tooltip(SettingsStrings.SKIP_TOOLTIP));
+    } else {
+      skipButton.setTooltip(null);
+      if (skipHost != null && skipDisabledTip != null) {
+        SettingsControls.setDisabledTooltip(
+            skipHost, skipDisabledTip, SettingsStrings.SKIP_UNAVAILABLE_TOOLTIP);
+      }
+    }
   }
 }

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SettingsShell.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SettingsShell.java
@@ -25,6 +25,7 @@ public final class SettingsShell {
   public static final String TITLE_ID = "settings-title";
   public static final String RUN_BUTTON_ID = "settings-run";
   public static final String CANCEL_BUTTON_ID = "settings-cancel";
+  public static final String SKIP_BUTTON_ID = "settings-skip";
   public static final String PROGRESS_ID = "settings-progress";
 
   private SettingsShell() {}
@@ -54,6 +55,12 @@ public final class SettingsShell {
     progress.setMaxWidth(Double.MAX_VALUE);
     HBox.setHgrow(progress, Priority.ALWAYS);
 
+    Button skip = new Button(SettingsStrings.SKIP);
+    skip.setId(SKIP_BUTTON_ID);
+    skip.getStyleClass().add(Styles.BUTTON_OUTLINED);
+    skip.setDisable(true);
+    StackPane skipHost = SettingsControls.wrapForDisabledTooltip(skip);
+
     Button cancel = new Button(SettingsStrings.CANCEL);
     cancel.setId(CANCEL_BUTTON_ID);
     cancel.getStyleClass().add(Styles.BUTTON_OUTLINED);
@@ -64,12 +71,12 @@ public final class SettingsShell {
     run.getStyleClass().add(Styles.ACCENT);
     run.setDefaultButton(true);
 
-    HBox bar = new HBox(SettingsLayout.GAP_MD, progress, cancel, run);
+    HBox bar = new HBox(SettingsLayout.GAP_MD, progress, skipHost, cancel, run);
     bar.setAlignment(Pos.CENTER_LEFT);
     bar.getStyleClass().add("settings-action-bar");
     root.setBottom(bar);
 
-    return new ShellResult(root, progress, run, cancel);
+    return new ShellResult(root, progress, run, cancel, skip);
   }
 
   private static Node buildHeader() {

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SettingsStrings.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SettingsStrings.java
@@ -51,9 +51,12 @@ public final class SettingsStrings {
   public static final String RESET_ALL_VISUALS_TOOLTIP =
       "Clear customizations for every visualization.";
   public static final String RESET_ALL_VISUALS_BUSY_TOOLTIP = "Unavailable while sorting.";
-  public static final String CONFIGURE_ORDER_UNAVAILABLE_TOOLTIP =
-      "Enable Run all to configure the algorithm order.";
   public static final String CONFIGURE_ORDER_BUSY_TOOLTIP = "Unavailable while sorting.";
+  public static final String SKIP = "Skip";
+  public static final String SKIP_TOOLTIP =
+      "Skip the current algorithm and continue with the next.";
+  public static final String SKIP_UNAVAILABLE_TOOLTIP =
+      "Skip is available while a Run-all session is running.";
   public static final String RESET_ALL = "Reset all";
   public static final String RESET_SETTING = "Reset";
   public static final String IMPORT = "Import";
@@ -89,13 +92,15 @@ public final class SettingsStrings {
   public static final String RESET_SETTING_TOOLTIP = "Reset to default";
   public static final String BROWSE = "Browse…";
   public static final String CONFIGURE_ORDER = "Configure order…";
-  public static final String RUN_ALL_ORDER_TITLE = "Configure run-all";
+  public static final String RUN_ALL_ORDER_TITLE = "Configure algorithms";
   public static final String RUN_ALL_ORDER_HINT =
-      "Check algorithms to include, then drag the handle to set the order they will run.";
+      "Drag to set the order for the algorithm dropdown and Run all. Check algorithms to include when Run all is on.";
   public static final String RUN_ALL_ORDER_SECTION = "ALGORITHMS";
   public static final String RUN_ALL_ORDER_COUNT = "%d selected";
   public static final String RUN_ALL_ORDER_COUNT_ONE = "1 selected";
   public static final String RUN_ALL_ORDER_EMPTY = "Select at least one algorithm to run.";
+  public static final String RUN_ALL_ORDER_UNSAVED_MESSAGE =
+      "Save your changes before closing, or discard them.";
   public static final String RUN_ALL_ORDER_SKIPPED = "-";
   public static final String RUN_ALL_ORDER_DRAG_TOOLTIP = "Drag to reorder";
   public static final String DONE = "Done";

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/ShellResult.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/ShellResult.java
@@ -5,4 +5,5 @@ import javafx.scene.control.ProgressBar;
 import javafx.scene.layout.BorderPane;
 
 /** Built Settings shell root plus action-bar controls for wiring. */
-public record ShellResult(BorderPane root, ProgressBar progress, Button run, Button cancel) {}
+public record ShellResult(
+    BorderPane root, ProgressBar progress, Button run, Button cancel, Button skip) {}

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SortingSection.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/SortingSection.java
@@ -121,6 +121,8 @@ public final class SortingSection {
                     }
                   }
                 });
+          } else if (AlgorithmViewModel.PROP_ENTRIES.equals(evt.getPropertyName())) {
+            VmBindings.runFx(() -> rebuildAlgorithmCombo(algorithm, nameToId, vm));
           } else if (AlgorithmViewModel.PROP_RUN_ALL.equals(evt.getPropertyName())) {
             boolean value = Boolean.TRUE.equals(evt.getNewValue());
             VmBindings.runFx(
@@ -165,17 +167,29 @@ public final class SortingSection {
     return root;
   }
 
+  private static void rebuildAlgorithmCombo(
+      ComboBox<String> algorithm, Map<String, String> nameToId, AlgorithmViewModel vm) {
+    String selectedId = vm.getSelectedId();
+    String selectedName = null;
+    nameToId.clear();
+    algorithm.getItems().clear();
+    for (AlgorithmDescriptor descriptor : vm.getDescriptors()) {
+      algorithm.getItems().add(descriptor.displayName());
+      nameToId.put(descriptor.displayName(), descriptor.id());
+      if (descriptor.id().equals(selectedId)) {
+        selectedName = descriptor.displayName();
+      }
+    }
+    if (selectedName != null) {
+      algorithm.getSelectionModel().select(selectedName);
+    }
+  }
+
   private static void syncConfigureState(
       Button configure, StackPane host, Tooltip tip, AlgorithmViewModel vm) {
-    boolean runAll = vm.isRunAll();
     boolean inputsEnabled = vm.isInputsEnabled();
-    configure.setDisable(!runAll || !inputsEnabled);
-    String reason = null;
-    if (!inputsEnabled) {
-      reason = SettingsStrings.CONFIGURE_ORDER_BUSY_TOOLTIP;
-    } else if (!runAll) {
-      reason = SettingsStrings.CONFIGURE_ORDER_UNAVAILABLE_TOOLTIP;
-    }
+    configure.setDisable(!inputsEnabled);
+    String reason = inputsEnabled ? null : SettingsStrings.CONFIGURE_ORDER_BUSY_TOOLTIP;
     SettingsControls.setDisabledTooltip(host, tip, reason);
   }
 }

--- a/src/main/java/io/github/compilerstuck/control/ui/settingsfx/vm/DisplayViewModel.java
+++ b/src/main/java/io/github/compilerstuck/control/ui/settingsfx/vm/DisplayViewModel.java
@@ -116,7 +116,7 @@ public final class DisplayViewModel {
       if (target != null && !target.toString().toLowerCase(Locale.ROOT).endsWith(".csv")) {
         target = Path.of(target + ".csv");
       }
-      app.getSessionManager().exportCsv(target, app.getAlgorithms());
+      app.getSessionManager().exportCsv(target, app.getSessionManager().getCompletedAlgorithms());
       return true;
     } catch (Exception ex) {
       LOGGER.log(Level.WARNING, "Failed to export CSV", ex);

--- a/src/main/java/io/github/compilerstuck/sortingalgorithms/SortingAlgorithm.java
+++ b/src/main/java/io/github/compilerstuck/sortingalgorithms/SortingAlgorithm.java
@@ -20,6 +20,14 @@ public abstract class SortingAlgorithm {
   protected OperationReporter operationReporter = OperationReporter.NOOP;
   protected CancellationToken cancellationToken = CancellationToken.alwaysActive();
 
+  /**
+   * Under equalize mode, only every {@code delayStride}-th {@link #delay}/{@link #delayFrame} waits
+   * on the FrameGate so huge step counts can still hit the duration target.
+   */
+  private int delayStride = 1;
+
+  private int delayPhase;
+
   ArrayModel arrayController;
 
   public SortingAlgorithm(ArrayModel arrayController) {
@@ -124,27 +132,44 @@ public abstract class SortingAlgorithm {
     delay(new int[0]);
   }
 
+  /** Visualize only every {@code stride}-th paced step (minimum 1). Resets the phase counter. */
+  public void setDelayStride(int stride) {
+    delayStride = Math.max(1, stride);
+    delayPhase = 0;
+  }
+
+  public int getDelayStride() {
+    return delayStride;
+  }
+
   private void pace(int[] markers, boolean wholeFrame) {
     if (isCancelled()) {
       return;
     }
-    if (delay) {
-      if (!timing) {
-        beginTiming();
-      } else {
-        arrayController.addRealTime((double) (System.nanoTime() - startTime));
-      }
-
-      for (int i : markers) {
-        arrayController.setMarker(i, Marker.SET);
-      }
-
-      if (wholeFrame) {
-        proc.delayFrame();
-      } else {
-        proc.delay();
-      }
-      startTime = System.nanoTime();
+    if (!delay) {
+      return;
     }
+
+    delayPhase++;
+    if (delayPhase % delayStride != 0) {
+      return;
+    }
+
+    if (!timing) {
+      beginTiming();
+    } else {
+      arrayController.addRealTime((double) (System.nanoTime() - startTime));
+    }
+
+    for (int i : markers) {
+      arrayController.setMarker(i, Marker.SET);
+    }
+
+    if (wholeFrame) {
+      proc.delayFrame();
+    } else {
+      proc.delay();
+    }
+    startTime = System.nanoTime();
   }
 }

--- a/src/test/java/io/github/compilerstuck/control/model/EqualizePacingTest.java
+++ b/src/test/java/io/github/compilerstuck/control/model/EqualizePacingTest.java
@@ -67,6 +67,25 @@ class EqualizePacingTest {
   }
 
   @Test
+  void exhaustedBudgetSprintsAtMaxStepsPerFrame() {
+    EqualizePacing pacing = new EqualizePacing();
+    pacing.begin(10, 0, 10f);
+    for (int i = 0; i < 10; i++) {
+      pacing.recordStep();
+    }
+    assertEquals(0, Math.max(0, pacing.totalSteps() - pacing.stepsConsumed()));
+    assertEquals(pacing.maxStepsPerFrame(), pacing.stepsForDelta(1f / 60f));
+  }
+
+  @Test
+  void stridedOverrideCapsGrantsToOnePerFrame() {
+    EqualizePacing pacing = new EqualizePacing();
+    pacing.begin(120, 0, 2f, 0, 1);
+    assertEquals(1, pacing.maxStepsPerFrame());
+    assertEquals(1, pacing.stepsForDelta(1f / 60f));
+  }
+
+  @Test
   void frameFloorHelperUnchanged() {
     assertEquals(2f, AppConfig.equalizeFrameFloorSec(120), 1e-4f);
     assertEquals(2f, AppConfig.effectiveEqualizeTargetSec(1f, 120), 1e-4f);

--- a/src/test/java/io/github/compilerstuck/control/model/EqualizeSortDurationSessionTest.java
+++ b/src/test/java/io/github/compilerstuck/control/model/EqualizeSortDurationSessionTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.github.compilerstuck.control.config.AppConfig;
 import io.github.compilerstuck.control.config.ShuffleType;
 import io.github.compilerstuck.control.render.CountingDelayContext;
 import io.github.compilerstuck.control.render.DelayContext;
@@ -52,6 +53,77 @@ class EqualizeSortDurationSessionTest {
     assertEquals(7, stateManager.equalizePacing().totalSteps());
     assertEquals(0, stateManager.equalizePacing().frameBeats());
     assertEquals(10f, stateManager.equalizePacing().effectiveTargetSec());
+    assertEquals(1, algorithm.getDelayStride());
+    assertFalse(stateManager.isEqualizePreparing());
+  }
+
+  @Test
+  @DisplayName("step count above equalize budget applies frame-based delay stride")
+  void excessStepsApplyDelayStride() {
+    // frameBudget = 60 * 0.1 = 6; highThroughput = 500 * 6 = 3000
+    // rawSteps 10_000 > 3000 → stride = ceil(10000/6) = 1667, visualSteps = 6, maxSPF = 1
+    sessionManager.setEqualizeSupport(() -> true, () -> 0.1, () -> NO_OP);
+    CountingSortStub algorithm = new CountingSortStub(array, 10_000);
+    assertTrue(sessionManager.tryArmEqualizePacing(algorithm, NO_OP));
+
+    assertEquals(1667, algorithm.getDelayStride());
+    EqualizePacing pacing = stateManager.equalizePacing();
+    assertTrue(pacing.isActive());
+    assertEquals(6, pacing.totalSteps());
+    assertEquals(1, pacing.maxStepsPerFrame());
+  }
+
+  @Test
+  @DisplayName("planDelayStride uses multi-credit budget when steps fit, else one beat per frame")
+  void planDelayStrideChoosesMode() {
+    SortingSessionManager.DelayStridePlan fits = SortingSessionManager.planDelayStride(1_000, 2f);
+    assertEquals(1, fits.stride());
+    assertEquals(1_000, fits.visualSteps());
+    assertEquals(AppConfig.EQUALIZE_MAX_STEPS_PER_FRAME, fits.maxStepsPerFrame());
+
+    // 2s → 120 frames; 1.25e9 steps need a large stride and 1 credit/frame
+    long bubbleRaw = SortingSessionManager.maxSwapDelaysUpperBound(50_000);
+    SortingSessionManager.DelayStridePlan strided =
+        SortingSessionManager.planDelayStride(bubbleRaw, 2f);
+    assertTrue(strided.stride() > 1);
+    assertEquals(1, strided.maxStepsPerFrame());
+    assertTrue(strided.visualSteps() <= 120 + 1, () -> "visual=" + strided.visualSteps());
+    assertTrue(strided.visualSteps() >= 120 - 1, () -> "visual=" + strided.visualSteps());
+  }
+
+  @Test
+  @DisplayName("dry-run timeout still arms equalize with estimated stride")
+  void dryRunTimeoutArmsWithEstimate() throws Exception {
+    sessionManager.setEqualizeSupport(() -> true, () -> 2.0, () -> NO_OP);
+    TimeoutAfterPartialStub algorithm = new TimeoutAfterPartialStub(array, 50, 2100);
+    assertTrue(sessionManager.tryArmEqualizePacing(algorithm, NO_OP));
+
+    assertTrue(algorithm.getDelayStride() >= 1);
+    assertTrue(stateManager.equalizePacing().isActive());
+    assertTrue(stateManager.equalizePacing().totalSteps() > 0);
+    assertFalse(stateManager.isEqualizePreparing());
+    assertFalse(stateManager.isFrameGateSuspended());
+  }
+
+  @Test
+  @DisplayName("estimateRawSteps distinguishes sparse vs swap-dense timeouts")
+  void estimateRawStepsExtrapolatesAndClamps() {
+    assertEquals(100, SortingSessionManager.estimateRawSteps(false, 100, 0.5, 40));
+    // Completed counts are not clamped to the swap upper bound.
+    assertEquals(10_000, SortingSessionManager.estimateRawSteps(false, 10_000, 0, 40));
+
+    // Swap-dense timeout (partial ≥ n): quadratic upper bound.
+    assertEquals(
+        SortingSessionManager.maxSwapDelaysUpperBound(40),
+        SortingSessionManager.estimateRawSteps(true, 40, 0.01, 40));
+    assertEquals(
+        SortingSessionManager.maxSwapDelaysUpperBound(50),
+        SortingSessionManager.estimateRawSteps(true, 0, 0, 50));
+
+    // Sparse timeout (Selection-like, partial < n): extrapolate toward ~n, not n²/2.
+    long sparse = SortingSessionManager.estimateRawSteps(true, 5, 5.0 / 50_000, 50_000);
+    assertEquals(50_000, sparse);
+    assertTrue(sparse < SortingSessionManager.maxSwapDelaysUpperBound(50_000) / 100);
   }
 
   @Test
@@ -146,6 +218,7 @@ class EqualizeSortDurationSessionTest {
 
     SlowCountingStub slow = new SlowCountingStub(array, 3, 80);
     boolean[] sawSuspended = {false};
+    boolean[] sawPreparing = {false};
     Thread sampler =
         new Thread(
             () -> {
@@ -153,6 +226,11 @@ class EqualizeSortDurationSessionTest {
               while (System.nanoTime() < deadline) {
                 if (stateManager.isFrameGateSuspended()) {
                   sawSuspended[0] = true;
+                }
+                if (stateManager.isEqualizePreparing()) {
+                  sawPreparing[0] = true;
+                }
+                if (sawSuspended[0] && sawPreparing[0]) {
                   return;
                 }
                 Thread.onSpinWait();
@@ -163,7 +241,9 @@ class EqualizeSortDurationSessionTest {
     assertTrue(sessionManager.tryArmEqualizePacing(slow, NO_OP));
     sampler.join(3000);
     assertTrue(sawSuspended[0], "dry-run should suspend FrameGate while counting");
+    assertTrue(sawPreparing[0], "dry-run should set equalizePreparing while counting");
     assertFalse(stateManager.isFrameGateSuspended());
+    assertFalse(stateManager.isEqualizePreparing());
     assertEquals(0, gate.availableCredits());
   }
 
@@ -253,6 +333,37 @@ class EqualizeSortDurationSessionTest {
         Thread.currentThread().interrupt();
       }
       for (int i = 0; i < steps && !isCancelled(); i++) {
+        delay();
+      }
+    }
+  }
+
+  /**
+   * Fires {@code partialSteps} delays, sleeps past the equalize dry-run deadline, then attempts
+   * more delays so {@link CountingDelayContext} times out with a non-zero partial count.
+   */
+  private static final class TimeoutAfterPartialStub extends SortingAlgorithm {
+    private final int partialSteps;
+    private final long sleepMs;
+
+    TimeoutAfterPartialStub(ArrayModel model, int partialSteps, long sleepMs) {
+      super(model, NO_OP);
+      this.partialSteps = partialSteps;
+      this.sleepMs = sleepMs;
+      this.name = "TimeoutAfterPartialStub";
+    }
+
+    @Override
+    public void sort() {
+      for (int i = 0; i < partialSteps && !isCancelled(); i++) {
+        delay();
+      }
+      try {
+        Thread.sleep(sleepMs);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      for (int i = 0; i < partialSteps && !isCancelled(); i++) {
         delay();
       }
     }

--- a/src/test/java/io/github/compilerstuck/control/model/SortingSessionManagerTest.java
+++ b/src/test/java/io/github/compilerstuck/control/model/SortingSessionManagerTest.java
@@ -148,6 +148,29 @@ class SortingSessionManagerTest {
   }
 
   @Test
+  @DisplayName("skip mid-run advances to the next algorithm without recording the skipped one")
+  void skipCurrentAdvancesToNextAlgorithm() {
+    UntilCancelledAlgorithm first = new UntilCancelledAlgorithm(arrayModel);
+    InstantSortAlgorithm second = new InstantSortAlgorithm(arrayModel);
+    stateManager.setRunning(true);
+    stateManager.setShowComparisonTable(true);
+
+    sessionManager.startSortingSession(List.of(first, second));
+
+    awaitUntilRunning(first);
+    sessionManager.skipCurrent();
+    sessionManager.waitForCompletion();
+
+    assertTrue(stateManager.shouldContinueExecution());
+    assertEquals(1, sessionManager.getCompletedAlgorithms().size());
+    assertEquals("InstantSort", sessionManager.getCompletedAlgorithms().get(0).getName());
+    assertEquals(1, sessionManager.getComparisons().size());
+    assertTrue(stateManager.shouldShowResults());
+    assertTrue(stateManager.shouldRestart());
+    assertFalse(stateManager.isRunning());
+  }
+
+  @Test
   @DisplayName("cancel mid-run stops execution and clears running state")
   void cancelMidRunStopsExecution() {
     UntilCancelledAlgorithm algorithm = new UntilCancelledAlgorithm(arrayModel);

--- a/src/test/java/io/github/compilerstuck/control/model/SortingStateManagerTest.java
+++ b/src/test/java/io/github/compilerstuck/control/model/SortingStateManagerTest.java
@@ -49,6 +49,8 @@ class SortingStateManagerTest {
     state.setShowResults(true);
     state.setRestart(true);
     state.setShuffling(true);
+    state.setFrameGateSuspended(true);
+    state.setEqualizePreparing(true);
     state.setCurrentOperation("Bubble Sort");
 
     state.resetForNewRun();
@@ -58,6 +60,8 @@ class SortingStateManagerTest {
     assertFalse(state.shouldShowResults());
     assertFalse(state.shouldRestart());
     assertFalse(state.isShuffling());
+    assertFalse(state.isFrameGateSuspended());
+    assertFalse(state.isEqualizePreparing());
     assertEquals("Waiting", state.getCurrentOperation());
   }
 
@@ -79,6 +83,23 @@ class SortingStateManagerTest {
     assertTrue(state.isFrameGateSuspended());
     state.resetForNewRun();
     assertFalse(state.isFrameGateSuspended());
+  }
+
+  @Test
+  @DisplayName("equalizePreparing flag round-trips and clears on reset")
+  void equalizePreparingRoundTrip() {
+    assertFalse(state.isEqualizePreparing());
+    state.setEqualizePreparing(true);
+    state.setEqualizePrepareProgress(40);
+    assertTrue(state.isEqualizePreparing());
+    assertEquals(40, state.getEqualizePrepareProgress());
+    state.setEqualizePreparing(false);
+    assertEquals(0, state.getEqualizePrepareProgress());
+    state.setEqualizePreparing(true);
+    state.setEqualizePrepareProgress(80);
+    state.resetForNewRun();
+    assertFalse(state.isEqualizePreparing());
+    assertEquals(0, state.getEqualizePrepareProgress());
   }
 
   @Test

--- a/src/test/java/io/github/compilerstuck/control/render/HudRendererTest.java
+++ b/src/test/java/io/github/compilerstuck/control/render/HudRendererTest.java
@@ -57,4 +57,34 @@ class HudRendererTest {
     assertEquals("Bubble Sort", hud.labelsForTest()[0]);
     assertTrue(hud.wouldSkipRebuild(state, array, rs.getWidth()));
   }
+
+  @Test
+  void prepareKeepsEndOfShuffleMetricsFrozenAgainstCounterChurn() {
+    for (int i = 0; i < 16; i++) {
+      array.set(i, 15 - i);
+    }
+    array.update();
+    state.setCurrentOperation("Shuffling");
+    hud.drawMeasurements(rs, state, array);
+    String sortedLine = hud.labelsForTest()[1];
+    String comparisonsLine = hud.labelsForTest()[2];
+
+    state.setCurrentOperation("Prepare.. 0%");
+    state.setEqualizePreparing(true);
+    array.addComparisons(1_000);
+    array.addWritesAux(50);
+    hud.drawMeasurements(rs, state, array);
+
+    String[] labels = hud.labelsForTest();
+    assertEquals("Prepare.. 0%", labels[0]);
+    assertEquals(sortedLine, labels[1], "sorted % must stay at end-of-shuffle value");
+    assertEquals(comparisonsLine, labels[2], "counters must stay frozen during Prepare..");
+    assertEquals("16 Elements", labels[7]);
+
+    state.setCurrentOperation("Prepare.. 42%");
+    hud.drawMeasurements(rs, state, array);
+    assertEquals("Prepare.. 42%", hud.labelsForTest()[0]);
+    assertEquals(sortedLine, hud.labelsForTest()[1]);
+    assertTrue(hud.wouldSkipRebuild(state, array, rs.getWidth()));
+  }
 }

--- a/src/test/java/io/github/compilerstuck/control/render/PrepareProgressDelayContextTest.java
+++ b/src/test/java/io/github/compilerstuck/control/render/PrepareProgressDelayContextTest.java
@@ -1,0 +1,43 @@
+package io.github.compilerstuck.control.render;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class PrepareProgressDelayContextTest {
+
+  @Test
+  void reportsZeroThenHundredOnComplete() {
+    List<String> labels = new ArrayList<>();
+    AtomicInteger progress = new AtomicInteger(-1);
+    CountingDelayContext counter = new CountingDelayContext();
+    long start = System.nanoTime();
+    PrepareProgressDelayContext ctx =
+        new PrepareProgressDelayContext(counter, start, 1_000_000_000L, labels::add, progress::set);
+
+    assertEquals(List.of("Prepare.. 0%"), labels);
+    assertEquals(0, progress.get());
+
+    ctx.complete();
+    assertEquals("Prepare.. 100%", labels.get(labels.size() - 1));
+    assertEquals(100, progress.get());
+    assertEquals(0, counter.stepCount());
+  }
+
+  @Test
+  void delayDelegatesToCounter() {
+    CountingDelayContext counter = new CountingDelayContext();
+    PrepareProgressDelayContext ctx =
+        new PrepareProgressDelayContext(
+            counter, System.nanoTime(), 1_000_000_000L, s -> {}, pct -> {});
+    ctx.delay();
+    ctx.delayFrame();
+    assertEquals(2, counter.stepCount());
+    assertEquals(1, counter.frameBeatCount());
+    assertTrue(ctx.counter() == counter);
+  }
+}

--- a/src/test/java/io/github/compilerstuck/control/ui/settingsfx/RunAllOrderDialogDirtyTest.java
+++ b/src/test/java/io/github/compilerstuck/control/ui/settingsfx/RunAllOrderDialogDirtyTest.java
@@ -1,0 +1,49 @@
+package io.github.compilerstuck.control.ui.settingsfx;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RunAllOrderDialogDirtyTest {
+
+  @Test
+  void matchingOrderAndSelectionIsClean() {
+    List<RunAllOrderDialog.DraftRow> rows =
+        List.of(
+            new RunAllOrderDialog.DraftRow("a", "A", true),
+            new RunAllOrderDialog.DraftRow("b", "B", false));
+    List<RunAllOrderDialog.BaselineRow> baseline =
+        List.of(
+            new RunAllOrderDialog.BaselineRow("a", true),
+            new RunAllOrderDialog.BaselineRow("b", false));
+    assertFalse(RunAllOrderDialog.isDirty(rows, baseline));
+  }
+
+  @Test
+  void reorderedIdsAreDirty() {
+    List<RunAllOrderDialog.DraftRow> rows =
+        List.of(
+            new RunAllOrderDialog.DraftRow("b", "B", false),
+            new RunAllOrderDialog.DraftRow("a", "A", true));
+    List<RunAllOrderDialog.BaselineRow> baseline =
+        List.of(
+            new RunAllOrderDialog.BaselineRow("a", true),
+            new RunAllOrderDialog.BaselineRow("b", false));
+    assertTrue(RunAllOrderDialog.isDirty(rows, baseline));
+  }
+
+  @Test
+  void selectionChangeIsDirty() {
+    List<RunAllOrderDialog.DraftRow> rows =
+        List.of(
+            new RunAllOrderDialog.DraftRow("a", "A", false),
+            new RunAllOrderDialog.DraftRow("b", "B", false));
+    List<RunAllOrderDialog.BaselineRow> baseline =
+        List.of(
+            new RunAllOrderDialog.BaselineRow("a", true),
+            new RunAllOrderDialog.BaselineRow("b", false));
+    assertTrue(RunAllOrderDialog.isDirty(rows, baseline));
+  }
+}

--- a/src/test/java/io/github/compilerstuck/control/ui/settingsfx/SettingsShellSmokeTest.java
+++ b/src/test/java/io/github/compilerstuck/control/ui/settingsfx/SettingsShellSmokeTest.java
@@ -61,6 +61,11 @@ class SettingsShellSmokeTest extends ApplicationTest {
     assertNotNull(cancel);
     assertEquals(SettingsStrings.CANCEL, cancel.getText());
 
+    Button skip = lookup("#" + SettingsShell.SKIP_BUTTON_ID).queryAs(Button.class);
+    assertNotNull(skip);
+    assertEquals(SettingsStrings.SKIP, skip.getText());
+    assertTrue(skip.isDisable());
+
     assertNotNull(lookup("#" + SoundSection.ROOT_ID).query());
     assertNotNull(lookup("#" + SpeedSection.ROOT_ID).query());
     assertNotNull(lookup("#" + DisplaySection.ROOT_ID).query());

--- a/src/test/java/io/github/compilerstuck/control/ui/settingsfx/vm/AlgorithmViewModelTest.java
+++ b/src/test/java/io/github/compilerstuck/control/ui/settingsfx/vm/AlgorithmViewModelTest.java
@@ -81,6 +81,8 @@ class AlgorithmViewModelTest {
     vm.applyRunAllOrder(ordered, Set.of(secondId));
     assertEquals(secondId, vm.getEntries().get(0).getId());
     assertEquals(firstId, vm.getEntries().get(1).getId());
+    assertEquals(secondId, vm.getDescriptors().get(0).id());
+    assertEquals(firstId, vm.getDescriptors().get(1).id());
     assertTrue(vm.getEntries().get(0).isSelected());
     assertFalse(vm.getEntries().get(1).isSelected());
   }

--- a/src/test/java/io/github/compilerstuck/sortingalgorithms/SortingAlgorithmDelayStrideTest.java
+++ b/src/test/java/io/github/compilerstuck/sortingalgorithms/SortingAlgorithmDelayStrideTest.java
@@ -1,0 +1,52 @@
+package io.github.compilerstuck.sortingalgorithms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.github.compilerstuck.control.model.ArrayController;
+import io.github.compilerstuck.control.render.CountingDelayContext;
+import org.junit.jupiter.api.Test;
+
+class SortingAlgorithmDelayStrideTest {
+
+  @Test
+  void delayStrideSkipsGateWaitsBetweenHits() {
+    ArrayController array = new ArrayController(8);
+    CountingDelayContext counter = new CountingDelayContext();
+    StrideProbe probe = new StrideProbe(array, 20);
+    probe.setDelayContext(counter);
+    probe.setDelayStride(5);
+    probe.sort();
+    // Stride skips plain delay() waits; frame beats stay at 0.
+    assertEquals(4, counter.stepCount());
+    assertEquals(0, counter.frameBeatCount());
+    assertEquals(5, probe.getDelayStride());
+  }
+
+  @Test
+  void delayStrideOneCountsEveryCall() {
+    ArrayController array = new ArrayController(8);
+    CountingDelayContext counter = new CountingDelayContext();
+    StrideProbe probe = new StrideProbe(array, 11);
+    probe.setDelayContext(counter);
+    probe.setDelayStride(1);
+    probe.sort();
+    assertEquals(11, counter.stepCount());
+  }
+
+  private static final class StrideProbe extends SortingAlgorithm {
+    private final int calls;
+
+    StrideProbe(ArrayController model, int calls) {
+      super(model);
+      this.calls = calls;
+      this.name = "StrideProbe";
+    }
+
+    @Override
+    public void sort() {
+      for (int i = 0; i < calls && !isCancelled(); i++) {
+        delay();
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Show **Prepare..** progress in the HUD (and settings) during equalize dry-runs so the phase is visible instead of looking frozen
- Add **delay stride** so high-step algorithms can still hit the equalize target duration within the per-frame budget
- Allow **skipping the current algorithm** mid-session and continue with the next; improve Run All order dialog dirty tracking

## Test plan
- [x] `./mvnw --batch-mode test -Dspotless.check.skip=true` (362 tests)
- [ ] Enable equalize sort duration and run a slow algorithm — confirm Prepare.. % appears, then sorting paces to the slider target
- [ ] Run multiple algorithms; press the skip key — current alg aborts and the next starts
- [ ] Open Run All order dialog, reorder/toggle selection — dirty state and Apply behave correctly
- [ ] CI green on this PR