### PR TITLE
feat: overlap equalize dry-run with shuffle and harden large-n pacing

### DIFF
--- a/src/main/java/io/github/compilerstuck/control/config/AppConfig.java
+++ b/src/main/java/io/github/compilerstuck/control/config/AppConfig.java
@@ -58,22 +58,38 @@ public final class AppConfig {
    * Shuffle animation length in seconds. Pacing uses a fixed visual-step budget (not the sort speed
    * setting).
    */
-  public static final float SHUFFLE_DURATION_SEC = 1f;
+  public static final float SHUFFLE_DURATION_SEC = 1.5f;
 
   /** Frame-gate steps fired across one shuffle animation ({@link #SHUFFLE_DURATION_SEC}). */
   public static final int SHUFFLE_VISUAL_STEPS = 1000;
 
   /**
    * Max wall time for the silent dry-run that counts visual steps before an equalized sort. On
-   * timeout, equalization is skipped for that algorithm.
+   * timeout, step totals are extrapolated via {@code estimateRawSteps}. Matches {@link
+   * #SHUFFLE_DURATION_SEC} so prep fits under the shuffle visual cover; {@code n log n} sorts
+   * usually finish with an exact count inside this budget.
    */
-  public static final long EQUALIZE_DRY_RUN_TIMEOUT_MS = 2000L;
+  public static final long EQUALIZE_DRY_RUN_TIMEOUT_MS = Math.round(SHUFFLE_DURATION_SEC * 1000f);
 
   /**
    * Soft cap on equalize step credits granted per draw frame (plain {@code delay()} algorithms).
    * Prevents a single frame from executing hundreds of thousands of visualized ops.
    */
   public static final int EQUALIZE_MAX_STEPS_PER_FRAME = 500;
+
+  /**
+   * Cap on {@code delayStride}: max undelayed {@code delay()} calls between FrameGate waits.
+   * Without this, Bubble/Shaker at large n use multi-million strides and freeze the UI for seconds
+   * per frame.
+   */
+  public static final int EQUALIZE_MAX_DELAY_STRIDE = 250_000;
+
+  /**
+   * Soft cap on undelayed equalize work (delay×stride) credited in one draw frame when catch-up
+   * grants are enabled. Keeps large-n strided runs nearer the slider target without multi-second
+   * freezes.
+   */
+  public static final int EQUALIZE_MAX_WORK_PER_FRAME = 1_000_000;
 
   /**
    * Approx bar-update budget per frame when batching {@code delayFrame} algorithms (e.g. Gravity

--- a/src/main/java/io/github/compilerstuck/control/model/ArrayController.java
+++ b/src/main/java/io/github/compilerstuck/control/model/ArrayController.java
@@ -5,9 +5,13 @@ import io.github.compilerstuck.control.config.ShuffleType;
 import io.github.compilerstuck.control.render.DelayContext;
 import io.github.compilerstuck.control.shuffle.AlmostSortedShuffleStrategy;
 import io.github.compilerstuck.control.shuffle.RandomShuffleStrategy;
+import io.github.compilerstuck.control.shuffle.RecordedShuffle;
 import io.github.compilerstuck.control.shuffle.ReverseShuffleStrategy;
 import io.github.compilerstuck.control.shuffle.SortedShuffleStrategy;
+import io.github.compilerstuck.control.shuffle.SwapRecordingModel;
 import io.github.compilerstuck.visual.Marker;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class ArrayController implements ArrayModel {
@@ -265,6 +269,64 @@ public class ArrayController implements ArrayModel {
     shuffleStrategy.shuffle(this, delayContext, operationReporter, cancellationToken);
     markMetricsDirty();
     bumpVisualRevision();
+  }
+
+  /**
+   * Runs the configured shuffle with no pacing, recording swap pairs so {@link
+   * #replayRecordedShuffle(RecordedShuffle)} can animate the same permutation.
+   */
+  public RecordedShuffle captureMuteShuffle() {
+    int[] pre = Arrays.copyOf(array, length);
+    if (cancellationToken.isCancelled()) {
+      return new RecordedShuffle(pre, pre, new int[0]);
+    }
+    List<Integer> pairs = SwapRecordingModel.newPairList();
+    SwapRecordingModel recorder = new SwapRecordingModel(this, pairs);
+    DelayContext noop =
+        () -> {
+          /* mute */
+        };
+    shuffleStrategy.shuffle(recorder, noop, OperationReporter.NOOP, cancellationToken);
+    markMetricsDirty();
+    bumpVisualRevision();
+    int[] post = Arrays.copyOf(array, length);
+    return new RecordedShuffle(pre, post, recorder.swapPairsArray());
+  }
+
+  /**
+   * Restores the pre-shuffle state, replays recorded swaps (or a marker sweep) with the current
+   * {@link DelayContext}, then forces the post-shuffle permutation.
+   */
+  public void replayRecordedShuffle(RecordedShuffle recorded) {
+    if (recorded == null) {
+      throw new IllegalArgumentException("recorded");
+    }
+    if (recorded.length() != length) {
+      throw new IllegalArgumentException("recording length must match array length");
+    }
+    restoreContents(recorded.pre());
+    int swaps = recorded.swapCount();
+    if (swaps == 0) {
+      int n = Math.max(1, length);
+      for (int i = 0; i < length && !cancellationToken.isCancelled(); i++) {
+        setMarker(i, Marker.SET);
+        int denom = Math.max(1, n - 1);
+        operationReporter.report("Shuffling.. " + (int) ((double) i / denom * 100) + "%");
+        RandomShuffleStrategy.maybeDelay(delayContext, i, n);
+      }
+    } else {
+      for (int s = 0; s < swaps && !cancellationToken.isCancelled(); s++) {
+        int i = recorded.swapI(s);
+        int j = recorded.swapJ(s);
+        swap(i, j);
+        setMarker(i, Marker.SET);
+        setMarker(j, Marker.SET);
+        int denom = Math.max(1, swaps - 1);
+        operationReporter.report("Shuffling.. " + (int) ((double) s / denom * 100) + "%");
+        RandomShuffleStrategy.maybeDelay(delayContext, s, swaps);
+      }
+    }
+    restoreContents(recorded.post());
   }
 
   public void setDelayContext(DelayContext delayContext) {

--- a/src/main/java/io/github/compilerstuck/control/model/SortingSessionManager.java
+++ b/src/main/java/io/github/compilerstuck/control/model/SortingSessionManager.java
@@ -475,7 +475,8 @@ public class SortingSessionManager {
 
       if (equalizeFastForward) {
         // Work exceeds what responsive FrameGate pacing can finish near the target — run unbound.
-        // Keep delay=true so marker side-effects (and thus audio) still run; use a no-op DelayContext
+        // Keep delay=true so marker side-effects (and thus audio) still run; use a no-op
+        // DelayContext
         // so nothing waits on the FrameGate.
         algorithm.setDelay(true);
         algorithm.setDelayStride(1);

--- a/src/main/java/io/github/compilerstuck/control/model/SortingSessionManager.java
+++ b/src/main/java/io/github/compilerstuck/control/model/SortingSessionManager.java
@@ -5,6 +5,7 @@ import io.github.compilerstuck.control.render.CountingDelayContext;
 import io.github.compilerstuck.control.render.DelayContext;
 import io.github.compilerstuck.control.render.PrepareProgressDelayContext;
 import io.github.compilerstuck.control.render.TrackingDelayContext;
+import io.github.compilerstuck.control.shuffle.RecordedShuffle;
 import io.github.compilerstuck.control.ui.TimeEstimateFormat;
 import io.github.compilerstuck.sortingalgorithms.BogoSort;
 import io.github.compilerstuck.sortingalgorithms.GravitySort;
@@ -12,12 +13,14 @@ import io.github.compilerstuck.sortingalgorithms.SortingAlgorithm;
 import io.github.compilerstuck.sound.Sound;
 import java.io.IOException;
 import java.io.Writer;
+import java.lang.reflect.Constructor;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 import java.util.function.DoubleSupplier;
@@ -53,6 +56,13 @@ public class SortingSessionManager {
   private BooleanSupplier equalizeEnabled = () -> false;
   private DoubleSupplier equalizeTargetSec = () -> 10.0;
   private Supplier<DelayContext> productionDelayContext = () -> null;
+
+  /**
+   * When equalize cannot hit the slider target without multi-million undelayed batches, the visual
+   * pass runs with {@code delay=false} under a suspended FrameGate (full-speed CPU, live
+   * publishes).
+   */
+  private boolean equalizeFastForward;
 
   public SortingSessionManager(
       ArrayController arrayController, Sound sound, SortingStateManager stateManager) {
@@ -160,7 +170,7 @@ public class SortingSessionManager {
         }
 
         armAlgorithmToken(algorithm);
-        prepareForAlgorithm();
+        prepareForAlgorithm(algorithm);
 
         if (!stateManager.shouldContinueExecution()) {
           LOGGER.log(Level.INFO, "Sorting session cancelled by user");
@@ -226,8 +236,19 @@ public class SortingSessionManager {
     timestamps.add((int) (System.currentTimeMillis() / 1000L) - startTime);
   }
 
-  private void prepareForAlgorithm() {
+  private void prepareForAlgorithm(SortingAlgorithm algorithm) {
     sound.cutNotes();
+    stateManager.equalizePacing().clear();
+    equalizeFastForward = false;
+
+    // After a skip (or any incomplete sort) the working array is mid-permutation; always start the
+    // next shuffle from the identity so the animation begins from a fully sorted bar chart.
+    arrayController.resetArray();
+
+    if (shouldOverlapEqualizePrepare(algorithm)) {
+      prepareWithOverlappedEqualize(algorithm);
+      return;
+    }
 
     stateManager.setShuffling(true);
     try {
@@ -249,6 +270,185 @@ public class SortingSessionManager {
     arrayController.resetMeasurements();
   }
 
+  /** True when equalize dry-run can run under a shuffle visual cover (not Gravity/Bogo). */
+  private boolean shouldOverlapEqualizePrepare(SortingAlgorithm algorithm) {
+    return equalizeEnabled.getAsBoolean()
+        && algorithm != null
+        && !(algorithm instanceof BogoSort)
+        && !(algorithm instanceof GravitySort);
+  }
+
+  /**
+   * Mute-shuffle, dry-run on a clone in parallel, cover with a paced shuffle replay so Prepare..
+   * never appears on the happy path.
+   */
+  private void prepareWithOverlappedEqualize(SortingAlgorithm algorithm) {
+    // Mute capture must not run under an unsuspended gate: otherwise the render thread grants
+    // sort-speed credits nobody consumes, and replay drains that backlog in an instant.
+    stateManager.setFrameGateSuspended(true);
+    RecordedShuffle recorded;
+    CancellationToken dryToken = new CancellationToken();
+    long prepareStartNanos = System.nanoTime();
+    CompletableFuture<DryRunOutcome> dryRun;
+    try {
+      recorded = arrayController.captureMuteShuffle();
+      if (!stateManager.shouldContinueExecution() || cancellationToken.isCancelled()) {
+        return;
+      }
+      dryRun = startBackgroundDryRun(algorithm, recorded.post(), dryToken, prepareStartNanos);
+    } finally {
+      FrameGate gate = frameGate;
+      if (gate != null) {
+        gate.drain();
+      }
+      // Leave suspended only if we're about to enter the paced replay below; cancel exits here.
+      if (!stateManager.shouldContinueExecution() || cancellationToken.isCancelled()) {
+        stateManager.setFrameGateSuspended(false);
+      }
+    }
+
+    if (!stateManager.shouldContinueExecution() || cancellationToken.isCancelled()) {
+      return;
+    }
+
+    int[] shuffled = recorded.post();
+    stateManager.setShuffling(true);
+    stateManager.setFrameGateSuspended(false);
+    try {
+      arrayController.replayRecordedShuffle(recorded);
+      joinDryRunUnderShuffleCover(dryRun, dryToken);
+    } finally {
+      stateManager.setShuffling(false);
+      sound.cutNotes();
+      FrameGate gate = frameGate;
+      if (gate != null) {
+        gate.drain();
+      }
+    }
+
+    arrayController.restoreContents(shuffled);
+
+    if (!stateManager.shouldContinueExecution() || cancellationToken.isCancelled()) {
+      dryToken.cancel();
+      dryRun.cancel(true);
+      return;
+    }
+
+    DryRunOutcome outcome;
+    try {
+      outcome = dryRun.get(AppConfig.EQUALIZE_DRY_RUN_TIMEOUT_MS + 500L, TimeUnit.MILLISECONDS);
+    } catch (Exception e) {
+      dryToken.cancel();
+      LOGGER.log(Level.WARNING, "Equalize dry-run failed; falling back to live Prepare", e);
+      outcome = null;
+    }
+
+    float sliderTarget = (float) equalizeTargetSec.getAsDouble();
+    if (outcome == null) {
+      // Peer construction failed or dry-run crashed: sync live fallback (may show Prepare..).
+      DelayContext production = productionDelayContext.get();
+      DelayContext fallback =
+          production != null
+              ? production
+              : () -> {
+                /* no-op */
+              };
+      tryArmEqualizePacingLive(algorithm, fallback, sliderTarget);
+    } else if (!outcome.aborted()) {
+      armFromDryRunOutcome(algorithm, outcome, sliderTarget);
+    }
+
+    if (!stateManager.shouldContinueExecution() || cancellationToken.isCancelled()) {
+      return;
+    }
+
+    sleepWithoutStepCredits(delayBetweenMs, "Thread interrupted during delay");
+    arrayController.resetMeasurements();
+  }
+
+  private CompletableFuture<DryRunOutcome> startBackgroundDryRun(
+      SortingAlgorithm algorithm,
+      int[] shuffled,
+      CancellationToken dryToken,
+      long prepareStartNanos) {
+    ArrayController clone = new ArrayController(shuffled.length);
+    clone.restoreContents(shuffled);
+    SortingAlgorithm peer = createPeerAlgorithm(algorithm, clone);
+    if (peer == null) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    CancellationToken sessionToken = cancellationToken;
+    long prepareTimeoutNanos = TimeUnit.MILLISECONDS.toNanos(AppConfig.EQUALIZE_DRY_RUN_TIMEOUT_MS);
+    CountingDelayContext counter =
+        new CountingDelayContext(
+            prepareStartNanos + prepareTimeoutNanos, sessionToken::isCancelled, dryToken::cancel);
+
+    return CompletableFuture.supplyAsync(
+        () -> {
+          peer.setDelayStride(1);
+          peer.setDelayContext(counter);
+          peer.setOperationReporter(OperationReporter.NOOP);
+          peer.setCancellationToken(dryToken);
+          try {
+            // CountingDelayContext does not play sound; avoid withMuted races with the session
+            // thread.
+            peer.sort();
+          } finally {
+            peer.endTiming();
+          }
+          clone.update();
+          return new DryRunOutcome(
+              counter.stepCount(),
+              counter.frameBeatCount(),
+              clone.getSortedPercentage(),
+              counter.timedOut(),
+              counter.aborted());
+        });
+  }
+
+  /**
+   * After the ~1s shuffle replay, wait for the dry-run if needed — without extending the shuffle
+   * animation/UI past {@link AppConfig#SHUFFLE_DURATION_SEC}. Suspends FrameGate and cuts MIDI.
+   */
+  private void joinDryRunUnderShuffleCover(
+      CompletableFuture<DryRunOutcome> dryRun, CancellationToken dryToken) {
+    // Suspend first so the next render frame republishes (markers cleared) instead of re-triggering
+    // noteOn from the last shuffle snapshot, then cut any note already sounding.
+    stateManager.setFrameGateSuspended(true);
+    sound.cutNotes();
+    if (dryRun.isDone()) {
+      stateManager.setFrameGateSuspended(false);
+      return;
+    }
+    // Keep shuffle label at 100% — do not stretch "Shuffling.." with prepare elapsed time.
+    stateManager.setCurrentOperation("Shuffling.. 100%");
+    try {
+      FrameGate gate = frameGate;
+      if (gate != null) {
+        gate.drain();
+      }
+      while (!dryRun.isDone()) {
+        if (!stateManager.shouldContinueExecution() || cancellationToken.isCancelled()) {
+          dryToken.cancel();
+          dryRun.cancel(true);
+          break;
+        }
+        try {
+          Thread.sleep(16L);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          dryToken.cancel();
+          dryRun.cancel(true);
+          break;
+        }
+      }
+    } finally {
+      stateManager.setFrameGateSuspended(false);
+      sound.cutNotes();
+    }
+  }
+
   private void executeAlgorithm(SortingAlgorithm algorithm) {
     DelayContext production = productionDelayContext.get();
     DelayContext fallback =
@@ -258,16 +458,44 @@ public class SortingSessionManager {
               /* no-op */
             };
     try {
-      algorithm.setDelayStride(1);
-      if (tryArmEqualizePacing(algorithm, fallback)) {
+      if (!equalizeFastForward && stateManager.equalizePacing().isActive()) {
+        // Armed during overlapped prepare; keep delayStride already set on the algorithm.
         algorithm.setDelayContext(
             new TrackingDelayContext(fallback, stateManager.equalizePacing()));
-      } else {
+      } else if (!equalizeFastForward && tryArmEqualizePacing(algorithm, fallback)) {
+        algorithm.setDelayContext(
+            new TrackingDelayContext(fallback, stateManager.equalizePacing()));
+      } else if (!equalizeFastForward) {
         if (algorithm instanceof GravitySort gravity) {
           gravity.setColumnStride(1);
         }
         algorithm.setDelayStride(1);
         algorithm.setDelayContext(fallback);
+      }
+
+      if (equalizeFastForward) {
+        // Work exceeds what responsive FrameGate pacing can finish near the target — run unbound.
+        // Keep delay=true so marker side-effects (and thus audio) still run; use a no-op DelayContext
+        // so nothing waits on the FrameGate.
+        algorithm.setDelay(true);
+        algorithm.setDelayStride(1);
+        algorithm.setDelayContext(
+            () -> {
+              /* no-op */
+            });
+        stateManager.setFrameGateSuspended(true);
+        sound.cutNotes();
+        FrameGate gate = frameGate;
+        if (gate != null) {
+          gate.drain();
+        }
+        algorithm.beginTiming();
+        try {
+          algorithm.sort();
+        } finally {
+          algorithm.endTiming();
+        }
+        return;
       }
 
       algorithm.beginTiming();
@@ -277,10 +505,13 @@ public class SortingSessionManager {
         algorithm.endTiming();
       }
     } finally {
+      equalizeFastForward = false;
+      stateManager.setFrameGateSuspended(false);
       stateManager.equalizePacing().clear();
       if (algorithm instanceof GravitySort gravity) {
         gravity.setColumnStride(1);
       }
+      algorithm.setDelay(true);
       algorithm.setDelayStride(1);
       algorithm.setDelayContext(fallback);
       // Drop unused equalize credits so awaitIdle cannot stall after a short/strided run.
@@ -296,6 +527,9 @@ public class SortingSessionManager {
    * When the counted (or estimated) step total exceeds the equalize frame budget, a delay stride is
    * applied so the visual pass can still hit the slider target.
    *
+   * <p>Prefer a clone + peer algorithm (no {@code Prepare..} UI). Falls back to a live dry-run with
+   * Prepare progress when a peer cannot be constructed (e.g. test stubs).
+   *
    * @return true when equalize pacing was armed for the visual pass
    */
   boolean tryArmEqualizePacing(SortingAlgorithm algorithm, DelayContext production) {
@@ -308,6 +542,9 @@ public class SortingSessionManager {
     }
     if (!stateManager.shouldContinueExecution() || cancellationToken.isCancelled()) {
       return false;
+    }
+    if (stateManager.equalizePacing().isActive()) {
+      return true;
     }
 
     float sliderTarget = (float) equalizeTargetSec.getAsDouble();
@@ -335,6 +572,30 @@ public class SortingSessionManager {
       return armEqualize(algorithm.getName(), visualBeats, visualBeats, sliderTarget, 0);
     }
 
+    int[] snapshot = Arrays.copyOf(arrayController.getArray(), arrayController.getLength());
+    ArrayController clone = new ArrayController(snapshot.length);
+    clone.restoreContents(snapshot);
+    SortingAlgorithm peer = createPeerAlgorithm(algorithm, clone);
+    if (peer != null) {
+      DryRunOutcome outcome = runDryRunOn(peer, clone, /* reportPrepare= */ false);
+      if (outcome == null || outcome.aborted()) {
+        return false;
+      }
+      if (!stateManager.shouldContinueExecution() || cancellationToken.isCancelled()) {
+        return false;
+      }
+      return armFromDryRunOutcome(algorithm, outcome, sliderTarget);
+    }
+
+    return tryArmEqualizePacingLive(algorithm, production, sliderTarget);
+  }
+
+  /**
+   * Live-array dry-run with {@code Prepare..} progress. Used when a peer algorithm cannot be
+   * constructed.
+   */
+  private boolean tryArmEqualizePacingLive(
+      SortingAlgorithm algorithm, DelayContext production, float sliderTarget) {
     int[] snapshot = Arrays.copyOf(arrayController.getArray(), arrayController.getLength());
     OperationReporter previousReporter = stateManager::setCurrentOperation;
     CancellationToken dryToken = new CancellationToken();
@@ -368,6 +629,8 @@ public class SortingSessionManager {
     long partialSteps = 0L;
     long partialFrameBeats = 0L;
     double progressSample = 0d;
+    boolean timedOut;
+    boolean aborted;
     try {
       sound.withMuted(algorithm::sort);
       progressCounter.complete();
@@ -375,6 +638,8 @@ public class SortingSessionManager {
       // Sample progress before restore so timeout extrapolation sees dry-run work.
       partialSteps = counter.stepCount();
       partialFrameBeats = counter.frameBeatCount();
+      timedOut = counter.timedOut();
+      aborted = counter.aborted();
       arrayController.update();
       progressSample = arrayController.getSortedPercentage();
 
@@ -394,27 +659,108 @@ public class SortingSessionManager {
     if (sessionToken.isCancelled() || !stateManager.shouldContinueExecution()) {
       return false;
     }
-    if (counter.aborted()) {
+    if (aborted) {
       return false;
     }
 
+    return armFromDryRunOutcome(
+        algorithm,
+        new DryRunOutcome(partialSteps, partialFrameBeats, progressSample, timedOut, false),
+        sliderTarget);
+  }
+
+  private DryRunOutcome runDryRunOn(
+      SortingAlgorithm peer, ArrayController target, boolean reportPrepare) {
+    CancellationToken dryToken = new CancellationToken();
+    CancellationToken sessionToken = cancellationToken;
+    long prepareStartNanos = System.nanoTime();
+    long prepareTimeoutNanos = TimeUnit.MILLISECONDS.toNanos(AppConfig.EQUALIZE_DRY_RUN_TIMEOUT_MS);
+    CountingDelayContext counter =
+        new CountingDelayContext(
+            prepareStartNanos + prepareTimeoutNanos, sessionToken::isCancelled, dryToken::cancel);
+    DelayContext delays = counter;
+    if (reportPrepare) {
+      delays =
+          new PrepareProgressDelayContext(
+              counter,
+              prepareStartNanos,
+              prepareTimeoutNanos,
+              stateManager::setCurrentOperation,
+              stateManager::setEqualizePrepareProgress);
+    }
+
+    peer.setDelayStride(1);
+    stateManager.setFrameGateSuspended(true);
+    if (reportPrepare) {
+      stateManager.setEqualizePreparing(true);
+    }
+    FrameGate gate = frameGate;
+    if (gate != null) {
+      gate.drain();
+    }
+
+    peer.setDelayContext(delays);
+    peer.setOperationReporter(OperationReporter.NOOP);
+    peer.setCancellationToken(dryToken);
+    try {
+      sound.withMuted(peer::sort);
+      if (delays instanceof PrepareProgressDelayContext progress) {
+        progress.complete();
+      }
+    } finally {
+      peer.endTiming();
+      if (gate != null) {
+        gate.drain();
+      }
+      if (reportPrepare) {
+        stateManager.setEqualizePreparing(false);
+      }
+      stateManager.setFrameGateSuspended(false);
+    }
+
+    if (sessionToken.isCancelled() || !stateManager.shouldContinueExecution()) {
+      return new DryRunOutcome(0, 0, 0, false, true);
+    }
+    target.update();
+    return new DryRunOutcome(
+        counter.stepCount(),
+        counter.frameBeatCount(),
+        target.getSortedPercentage(),
+        counter.timedOut(),
+        counter.aborted());
+  }
+
+  private boolean armFromDryRunOutcome(
+      SortingAlgorithm algorithm, DryRunOutcome outcome, float sliderTarget) {
     int n = arrayController.getLength();
-    long rawSteps = estimateRawSteps(counter.timedOut(), partialSteps, progressSample, n);
+    long rawSteps =
+        estimateRawSteps(outcome.timedOut(), outcome.partialSteps(), outcome.progressSample(), n);
     if (rawSteps <= 0) {
       return false;
     }
 
     DelayStridePlan plan = planDelayStride(rawSteps, sliderTarget);
+    if (plan.fastForward()) {
+      equalizeFastForward = true;
+      algorithm.setDelayStride(1);
+      LOGGER.log(
+          Level.INFO,
+          "Equalize fast-forward for {0}: rawSteps={1} exceeds responsive budget for {2}s target",
+          new Object[] {algorithm.getName(), rawSteps, sliderTarget});
+      return false;
+    }
+
     int stride = plan.stride();
     int visualSteps = plan.visualSteps();
 
-    long rawFrameBeats = partialFrameBeats;
-    if (counter.timedOut() && partialFrameBeats > 0L && partialSteps > 0L) {
-      // Scale frame-beat estimate in the same proportion as steps when extrapolating.
+    long rawFrameBeats = outcome.partialFrameBeats();
+    if (outcome.timedOut() && outcome.partialFrameBeats() > 0L && outcome.partialSteps() > 0L) {
       rawFrameBeats =
           Math.max(
-              partialFrameBeats,
-              Math.round(partialFrameBeats * ((double) rawSteps / (double) partialSteps)));
+              outcome.partialFrameBeats(),
+              Math.round(
+                  outcome.partialFrameBeats()
+                      * ((double) rawSteps / (double) outcome.partialSteps())));
     }
     int visualFrameBeats = 0;
     if (rawFrameBeats > 0L) {
@@ -422,7 +768,7 @@ public class SortingSessionManager {
     }
 
     algorithm.setDelayStride(stride);
-    if (counter.timedOut()) {
+    if (outcome.timedOut()) {
       LOGGER.log(
           Level.INFO,
           "Equalize dry-run timed out for {0}; estimated steps={1}, stride={2}, visualSteps={3}, maxSteps/frame={4}",
@@ -441,13 +787,45 @@ public class SortingSessionManager {
   }
 
   /**
+   * Constructs a fresh algorithm instance bound to {@code model} via the standard {@code
+   * (ArrayModel)} constructor. Returns null when that ctor is unavailable (test stubs).
+   */
+  static SortingAlgorithm createPeerAlgorithm(SortingAlgorithm prototype, ArrayModel model) {
+    if (prototype == null || model == null) {
+      return null;
+    }
+    try {
+      Constructor<? extends SortingAlgorithm> ctor =
+          prototype.getClass().getConstructor(ArrayModel.class);
+      SortingAlgorithm peer = ctor.newInstance(model);
+      if (prototype.getAlternativeSize() != 0) {
+        peer.setAlternativeSize(prototype.getAlternativeSize());
+      }
+      return peer;
+    } catch (ReflectiveOperationException e) {
+      return null;
+    }
+  }
+
+  /** Counts collected by a silent equalize dry-run. */
+  record DryRunOutcome(
+      long partialSteps,
+      long partialFrameBeats,
+      double progressSample,
+      boolean timedOut,
+      boolean aborted) {}
+
+  /**
    * Chooses delay stride so equalize can hit {@code sliderTarget}.
    *
    * <ul>
    *   <li>If {@code rawSteps} fits in {@code EQUALIZE_MAX_STEPS_PER_FRAME × 60 × target}, stride is
    *       1 and multi-credit frames are used.
-   *   <li>Otherwise stride is {@code ceil(rawSteps / (60 × target))} (one visual beat per frame)
-   *       and grants are capped at 1 so {@code awaitIdle} cannot stall on leftover credits.
+   *   <li>Otherwise stride is {@code ceil(rawSteps / (60 × target))}, capped at {@link
+   *       AppConfig#EQUALIZE_MAX_DELAY_STRIDE}. When the cap binds, multiple credits per frame are
+   *       allowed (up to the work budget) so the run can still approach the target.
+   *   <li>If even {@link AppConfig#EQUALIZE_MAX_WORK_PER_FRAME} × frameBudget cannot cover {@code
+   *       rawSteps}, {@link DelayStridePlan#fastForward()} is set — caller should run unbound.
    * </ul>
    */
   static DelayStridePlan planDelayStride(long rawSteps, float sliderTarget) {
@@ -457,15 +835,34 @@ public class SortingSessionManager {
     long highThroughputBudget = (long) AppConfig.EQUALIZE_MAX_STEPS_PER_FRAME * frameBudget;
     if (rawSteps <= highThroughputBudget) {
       return new DelayStridePlan(
-          1, clampToInt(rawSteps), AppConfig.EQUALIZE_MAX_STEPS_PER_FRAME, highThroughputBudget);
+          1,
+          clampToInt(rawSteps),
+          AppConfig.EQUALIZE_MAX_STEPS_PER_FRAME,
+          highThroughputBudget,
+          false);
     }
-    int stride = clampToInt(Math.max(1L, (rawSteps + frameBudget - 1L) / frameBudget));
+
+    long maxWork = (long) AppConfig.EQUALIZE_MAX_WORK_PER_FRAME * frameBudget;
+    if (rawSteps > maxWork) {
+      // Cannot finish near the target without multi-million batches per frame.
+      return new DelayStridePlan(1, 1, 1, frameBudget, true);
+    }
+
+    int idealStride = clampToInt(Math.max(1L, (rawSteps + frameBudget - 1L) / frameBudget));
+    int stride = Math.min(idealStride, AppConfig.EQUALIZE_MAX_DELAY_STRIDE);
     int visualSteps = clampToInt(Math.max(1L, (rawSteps + (long) stride - 1L) / stride));
-    return new DelayStridePlan(stride, visualSteps, 1, frameBudget);
+    int maxStepsPerFrame = 1;
+    if (stride < idealStride) {
+      int needed = clampToInt(Math.max(1L, ((long) visualSteps + frameBudget - 1L) / frameBudget));
+      int byWork = Math.max(1, AppConfig.EQUALIZE_MAX_WORK_PER_FRAME / Math.max(1, stride));
+      maxStepsPerFrame = Math.min(needed, byWork);
+    }
+    return new DelayStridePlan(stride, visualSteps, maxStepsPerFrame, frameBudget, false);
   }
 
   /** Result of {@link #planDelayStride(long, float)}. */
-  record DelayStridePlan(int stride, int visualSteps, int maxStepsPerFrame, long budget) {}
+  record DelayStridePlan(
+      int stride, int visualSteps, int maxStepsPerFrame, long budget, boolean fastForward) {}
 
   /**
    * Raw delay count for equalize arming. Completed dry-runs keep the counted total.
@@ -479,6 +876,10 @@ public class SortingSessionManager {
    *       sorted progress (floored at {@code n}) so we do not arm a Bubble-sized stride that skips
    *       almost every real delay and stalls {@code FrameGate.awaitIdle}.
    * </ul>
+   *
+   * <p>{@code n log n} sorts (Merge/Quick/…) are expected to finish the dry-run inside the timeout
+   * with an exact count ({@code timedOut == false}); do not apply the Bubble bound to a partial
+   * mid-run sample.
    */
   static long estimateRawSteps(boolean timedOut, long partialSteps, double progressSample, int n) {
     if (!timedOut) {

--- a/src/main/java/io/github/compilerstuck/control/shuffle/RandomShuffleStrategy.java
+++ b/src/main/java/io/github/compilerstuck/control/shuffle/RandomShuffleStrategy.java
@@ -30,7 +30,7 @@ public class RandomShuffleStrategy implements ShuffleStrategy {
    * steps (0-based index {@code i}). Small loops fire multiple delays per step so total pacing
    * stays ~1s.
    */
-  static void maybeDelay(DelayContext ctx, int i, int iterations) {
+  public static void maybeDelay(DelayContext ctx, int i, int iterations) {
     int steps = AppConfig.SHUFFLE_VISUAL_STEPS;
     int n = Math.max(1, iterations);
     int due = (int) ((long) (i + 1) * steps / n);

--- a/src/main/java/io/github/compilerstuck/control/shuffle/RecordedShuffle.java
+++ b/src/main/java/io/github/compilerstuck/control/shuffle/RecordedShuffle.java
@@ -1,0 +1,77 @@
+package io.github.compilerstuck.control.shuffle;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Snapshot of a mute shuffle: pre/post permutations plus recorded swap pairs for a paced visual
+ * replay that ends on the same post state.
+ */
+public final class RecordedShuffle {
+  private final int[] pre;
+  private final int[] post;
+
+  /** Flat {@code i,j} pairs in mute-shuffle order. */
+  private final int[] swapPairs;
+
+  public RecordedShuffle(int[] pre, int[] post, int[] swapPairs) {
+    this.pre = Objects.requireNonNull(pre, "pre").clone();
+    this.post = Objects.requireNonNull(post, "post").clone();
+    this.swapPairs = swapPairs != null ? swapPairs.clone() : new int[0];
+    if (this.pre.length != this.post.length) {
+      throw new IllegalArgumentException("pre/post length mismatch");
+    }
+    if ((this.swapPairs.length & 1) != 0) {
+      throw new IllegalArgumentException("swapPairs must contain i,j pairs");
+    }
+  }
+
+  public int[] pre() {
+    return pre.clone();
+  }
+
+  public int[] post() {
+    return post.clone();
+  }
+
+  public int[] swapPairs() {
+    return swapPairs.clone();
+  }
+
+  public int length() {
+    return pre.length;
+  }
+
+  public int swapCount() {
+    return swapPairs.length / 2;
+  }
+
+  public int swapI(int index) {
+    return swapPairs[index * 2];
+  }
+
+  public int swapJ(int index) {
+    return swapPairs[index * 2 + 1];
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof RecordedShuffle that)) {
+      return false;
+    }
+    return Arrays.equals(pre, that.pre)
+        && Arrays.equals(post, that.post)
+        && Arrays.equals(swapPairs, that.swapPairs);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Arrays.hashCode(pre);
+    result = 31 * result + Arrays.hashCode(post);
+    result = 31 * result + Arrays.hashCode(swapPairs);
+    return result;
+  }
+}

--- a/src/main/java/io/github/compilerstuck/control/shuffle/SwapRecordingModel.java
+++ b/src/main/java/io/github/compilerstuck/control/shuffle/SwapRecordingModel.java
@@ -1,0 +1,128 @@
+package io.github.compilerstuck.control.shuffle;
+
+import io.github.compilerstuck.control.model.ArrayModel;
+import io.github.compilerstuck.visual.Marker;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/** Delegates to a live model while recording every {@link #swap(int, int)} as flat {@code i,j}. */
+public final class SwapRecordingModel implements ArrayModel {
+  private final ArrayModel delegate;
+  private final List<Integer> swapPairs;
+
+  public SwapRecordingModel(ArrayModel delegate, List<Integer> swapPairs) {
+    this.delegate = Objects.requireNonNull(delegate, "delegate");
+    this.swapPairs = Objects.requireNonNull(swapPairs, "swapPairs");
+  }
+
+  public int[] swapPairsArray() {
+    int n = swapPairs.size();
+    int[] out = new int[n];
+    for (int i = 0; i < n; i++) {
+      out[i] = swapPairs.get(i);
+    }
+    return out;
+  }
+
+  public static List<Integer> newPairList() {
+    return new ArrayList<>();
+  }
+
+  @Override
+  public int getLength() {
+    return delegate.getLength();
+  }
+
+  @Override
+  public int get(int index) {
+    return delegate.get(index);
+  }
+
+  @Override
+  public void set(int index, int value) {
+    delegate.set(index, value);
+  }
+
+  @Override
+  public void swap(int i, int j) {
+    swapPairs.add(i);
+    swapPairs.add(j);
+    delegate.swap(i, j);
+  }
+
+  @Override
+  public Marker getMarker(int index) {
+    return delegate.getMarker(index);
+  }
+
+  @Override
+  public void setMarker(int index, Marker m) {
+    delegate.setMarker(index, m);
+  }
+
+  @Override
+  public void addComparisons(int n) {
+    delegate.addComparisons(n);
+  }
+
+  @Override
+  public void addWritesAux(int n) {
+    delegate.addWritesAux(n);
+  }
+
+  @Override
+  public void addRealTime(double timeNs) {
+    delegate.addRealTime(timeNs);
+  }
+
+  @Override
+  public long getComparisons() {
+    return delegate.getComparisons();
+  }
+
+  @Override
+  public long getSwaps() {
+    return delegate.getSwaps();
+  }
+
+  @Override
+  public long getWrites() {
+    return delegate.getWrites();
+  }
+
+  @Override
+  public long getWritesAux() {
+    return delegate.getWritesAux();
+  }
+
+  @Override
+  public double getRealTime() {
+    return delegate.getRealTime();
+  }
+
+  @Override
+  public double getSortedPercentage() {
+    return delegate.getSortedPercentage();
+  }
+
+  @Override
+  public int getSegments() {
+    return delegate.getSegments();
+  }
+
+  @Override
+  public boolean isSorted() {
+    return delegate.isSorted();
+  }
+
+  @Override
+  public int[] getArray() {
+    return delegate.getArray();
+  }
+
+  @Override
+  public long getVisualRevision() {
+    return delegate.getVisualRevision();
+  }
+}

--- a/src/main/java/io/github/compilerstuck/sortingalgorithms/SortingAlgorithm.java
+++ b/src/main/java/io/github/compilerstuck/sortingalgorithms/SortingAlgorithm.java
@@ -28,6 +28,11 @@ public abstract class SortingAlgorithm {
 
   private int delayPhase;
 
+  /** Indices highlighted on the previous visualized pace; cleared before the next highlight. */
+  private int[] lastMarkers = EMPTY_MARKERS;
+
+  private static final int[] EMPTY_MARKERS = new int[0];
+
   ArrayModel arrayController;
 
   public SortingAlgorithm(ArrayModel arrayController) {
@@ -161,9 +166,13 @@ public abstract class SortingAlgorithm {
       arrayController.addRealTime((double) (System.nanoTime() - startTime));
     }
 
+    // Replace highlights instead of accumulating — fast equalize batches would otherwise paint
+    // most of the array white before the next publish.
+    clearLastMarkers();
     for (int i : markers) {
       arrayController.setMarker(i, Marker.SET);
     }
+    lastMarkers = markers.length == 0 ? EMPTY_MARKERS : markers;
 
     if (wholeFrame) {
       proc.delayFrame();
@@ -171,5 +180,13 @@ public abstract class SortingAlgorithm {
       proc.delay();
     }
     startTime = System.nanoTime();
+  }
+
+  private void clearLastMarkers() {
+    for (int i : lastMarkers) {
+      if (i >= 0 && i < arrayController.getLength()) {
+        arrayController.setMarker(i, Marker.NORMAL);
+      }
+    }
   }
 }

--- a/src/test/java/io/github/compilerstuck/control/model/EqualizeSortDurationSessionTest.java
+++ b/src/test/java/io/github/compilerstuck/control/model/EqualizeSortDurationSessionTest.java
@@ -12,9 +12,11 @@ import io.github.compilerstuck.control.render.DelayContext;
 import io.github.compilerstuck.sortingalgorithms.BogoSort;
 import io.github.compilerstuck.sortingalgorithms.BubbleSort;
 import io.github.compilerstuck.sortingalgorithms.GravitySort;
+import io.github.compilerstuck.sortingalgorithms.MergeSort;
 import io.github.compilerstuck.sortingalgorithms.SortingAlgorithm;
 import io.github.compilerstuck.sound.Sound;
 import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -81,21 +83,28 @@ class EqualizeSortDurationSessionTest {
     assertEquals(1_000, fits.visualSteps());
     assertEquals(AppConfig.EQUALIZE_MAX_STEPS_PER_FRAME, fits.maxStepsPerFrame());
 
-    // 2s → 120 frames; 1.25e9 steps need a large stride and 1 credit/frame
+    // 2s → 120 frames; 1.25e9 Bubble steps exceed responsive work budget → fast-forward.
     long bubbleRaw = SortingSessionManager.maxSwapDelaysUpperBound(50_000);
     SortingSessionManager.DelayStridePlan strided =
         SortingSessionManager.planDelayStride(bubbleRaw, 2f);
-    assertTrue(strided.stride() > 1);
-    assertEquals(1, strided.maxStepsPerFrame());
-    assertTrue(strided.visualSteps() <= 120 + 1, () -> "visual=" + strided.visualSteps());
-    assertTrue(strided.visualSteps() >= 120 - 1, () -> "visual=" + strided.visualSteps());
+    assertTrue(strided.fastForward());
+
+    // Fits in work budget with capped stride + catch-up credits.
+    long mediumRaw = SortingSessionManager.maxSwapDelaysUpperBound(5_000);
+    SortingSessionManager.DelayStridePlan medium =
+        SortingSessionManager.planDelayStride(mediumRaw, 2f);
+    assertFalse(medium.fastForward());
+    assertTrue(medium.stride() > 1);
+    assertTrue(medium.stride() <= AppConfig.EQUALIZE_MAX_DELAY_STRIDE);
+    assertTrue(medium.maxStepsPerFrame() >= 1);
   }
 
   @Test
   @DisplayName("dry-run timeout still arms equalize with estimated stride")
   void dryRunTimeoutArmsWithEstimate() throws Exception {
     sessionManager.setEqualizeSupport(() -> true, () -> 2.0, () -> NO_OP);
-    TimeoutAfterPartialStub algorithm = new TimeoutAfterPartialStub(array, 50, 2100);
+    TimeoutAfterPartialStub algorithm =
+        new TimeoutAfterPartialStub(array, 50, AppConfig.EQUALIZE_DRY_RUN_TIMEOUT_MS + 100);
     assertTrue(sessionManager.tryArmEqualizePacing(algorithm, NO_OP));
 
     assertTrue(algorithm.getDelayStride() >= 1);
@@ -124,6 +133,26 @@ class EqualizeSortDurationSessionTest {
     long sparse = SortingSessionManager.estimateRawSteps(true, 5, 5.0 / 50_000, 50_000);
     assertEquals(50_000, sparse);
     assertTrue(sparse < SortingSessionManager.maxSwapDelaysUpperBound(50_000) / 100);
+
+    // Timed-out mid Merge-like sample with ≥ n delays uses Bubble bound (exact Merge counts
+    // come from a completed dry-run with timedOut=false instead).
+    assertEquals(
+        SortingSessionManager.maxSwapDelaysUpperBound(50_000),
+        SortingSessionManager.estimateRawSteps(true, 50_000, 0.10, 50_000));
+  }
+
+  @Test
+  @DisplayName("Merge Sort dry-run completes with exact step count (not Bubble n² bound)")
+  void mergeDryRunCompletesWithExactCount() {
+    reverseInPlace(array);
+    MergeSort merge = new MergeSort(array);
+    assertTrue(sessionManager.tryArmEqualizePacing(merge, NO_OP));
+
+    EqualizePacing pacing = stateManager.equalizePacing();
+    assertTrue(pacing.isActive());
+    // n=32 Merge is well under the dry-run timeout; exact count ≪ n²/2.
+    assertTrue(pacing.totalSteps() < SortingSessionManager.maxSwapDelaysUpperBound(32));
+    assertEquals(1, merge.getDelayStride());
   }
 
   @Test
@@ -210,6 +239,122 @@ class EqualizeSortDurationSessionTest {
   }
 
   @Test
+  @DisplayName("peer clone dry-run arms pacing without Prepare UI")
+  void cloneDryRunDoesNotSetPreparing() {
+    reverseInPlace(array);
+    int[] before = Arrays.copyOf(array.getArray(), array.getLength());
+    BubbleSort bubble = new BubbleSort(array);
+
+    boolean[] sawPreparing = {false};
+    Thread sampler =
+        new Thread(
+            () -> {
+              long deadline = System.nanoTime() + 2_000_000_000L;
+              while (System.nanoTime() < deadline) {
+                if (stateManager.isEqualizePreparing()) {
+                  sawPreparing[0] = true;
+                  return;
+                }
+                Thread.onSpinWait();
+              }
+            },
+            "prepare-sampler");
+    sampler.start();
+    assertTrue(sessionManager.tryArmEqualizePacing(bubble, NO_OP));
+    try {
+      sampler.join(3000);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+
+    assertFalse(sawPreparing[0], "clone dry-run must not set equalizePreparing");
+    assertArrayEquals(before, array.getArray());
+    assertTrue(stateManager.equalizePacing().isActive());
+    assertTrue(stateManager.equalizePacing().totalSteps() > 0);
+    assertFalse(stateManager.isEqualizePreparing());
+  }
+
+  @Test
+  @DisplayName("overlapped prepare hides Prepare and arms pacing under shuffle cover")
+  void overlappedPrepareHidesPrepareUi() throws Exception {
+    array.setShuffleType(ShuffleType.REVERSE);
+    array.setDelayContext(NO_OP);
+    array.setOperationReporter(OperationReporter.NOOP);
+
+    BubbleSort bubble = new BubbleSort(array);
+    boolean[] sawPreparing = {false};
+    Thread sampler =
+        new Thread(
+            () -> {
+              long deadline = System.nanoTime() + 5_000_000_000L;
+              while (System.nanoTime() < deadline) {
+                if (stateManager.isEqualizePreparing()) {
+                  sawPreparing[0] = true;
+                  return;
+                }
+                if (stateManager.shouldRestart()) {
+                  return;
+                }
+                Thread.onSpinWait();
+              }
+            },
+            "overlap-prepare-sampler");
+    sampler.start();
+
+    stateManager.setRunning(true);
+    sessionManager.startSortingSession(List.of(bubble));
+    sessionManager.waitForCompletion();
+    sampler.join(1000);
+
+    assertFalse(sawPreparing[0], "Prepare UI must stay hidden during overlapped prepare");
+    assertTrue(sessionManager.hasResults());
+    assertTrue(array.isSorted());
+    assertFalse(stateManager.isEqualizePreparing());
+    assertFalse(stateManager.isShuffling());
+  }
+
+  @Test
+  @DisplayName("cancel during overlapped prepare aborts without leaving Prepare stuck")
+  void cancelDuringOverlappedPrepare() throws Exception {
+    array.setShuffleType(ShuffleType.SORTED);
+    array.setDelayContext(NO_OP);
+    sessionManager.setEqualizeSupport(() -> true, () -> 10.0, () -> NO_OP);
+
+    SlowPeerSort slow = new SlowPeerSort(array);
+    stateManager.setRunning(true);
+    sessionManager.startSortingSession(List.of(slow));
+
+    long deadline = System.nanoTime() + 2_000_000_000L;
+    while (!stateManager.isShuffling() && System.nanoTime() < deadline) {
+      Thread.onSpinWait();
+    }
+    sessionManager.cancel();
+    sessionManager.waitForCompletion();
+
+    assertFalse(stateManager.isEqualizePreparing());
+    assertFalse(stateManager.isShuffling());
+    assertFalse(stateManager.isRunning());
+    assertFalse(sessionManager.hasResults());
+  }
+
+  @Test
+  @DisplayName("createPeerAlgorithm copies alternativeSize when present")
+  void createPeerCopiesAlternativeSize() {
+    BubbleSort bubble = new BubbleSort(array);
+    bubble.setAlternativeSize(99);
+    SortingAlgorithm peer = SortingSessionManager.createPeerAlgorithm(bubble, array);
+    assertTrue(peer instanceof BubbleSort);
+    assertEquals(99, peer.getAlternativeSize());
+  }
+
+  @Test
+  @DisplayName("createPeerAlgorithm returns null for stubs without ArrayModel ctor")
+  void createPeerReturnsNullForStub() {
+    CountingSortStub stub = new CountingSortStub(array, 3);
+    assertEquals(null, SortingSessionManager.createPeerAlgorithm(stub, array));
+  }
+
+  @Test
   @DisplayName("non-Gravity dry-run suspends FrameGate and drains leftover credits")
   void dryRunSuspendsFrameGate() throws Exception {
     FrameGate gate = new FrameGate();
@@ -241,7 +386,7 @@ class EqualizeSortDurationSessionTest {
     assertTrue(sessionManager.tryArmEqualizePacing(slow, NO_OP));
     sampler.join(3000);
     assertTrue(sawSuspended[0], "dry-run should suspend FrameGate while counting");
-    assertTrue(sawPreparing[0], "dry-run should set equalizePreparing while counting");
+    assertTrue(sawPreparing[0], "live fallback should set equalizePreparing while counting");
     assertFalse(stateManager.isFrameGateSuspended());
     assertFalse(stateManager.isEqualizePreparing());
     assertEquals(0, gate.availableCredits());
@@ -333,6 +478,26 @@ class EqualizeSortDurationSessionTest {
         Thread.currentThread().interrupt();
       }
       for (int i = 0; i < steps && !isCancelled(); i++) {
+        delay();
+      }
+    }
+  }
+
+  /** Peer-constructible algorithm that sleeps so cancel can hit mid dry-run / shuffle cover. */
+  private static final class SlowPeerSort extends SortingAlgorithm {
+    SlowPeerSort(ArrayModel model) {
+      super(model, NO_OP);
+      this.name = "SlowPeerSort";
+    }
+
+    @Override
+    public void sort() {
+      try {
+        Thread.sleep(1_500);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      for (int i = 0; i < 5 && !isCancelled(); i++) {
         delay();
       }
     }

--- a/src/test/java/io/github/compilerstuck/control/model/SortingSessionManagerTest.java
+++ b/src/test/java/io/github/compilerstuck/control/model/SortingSessionManagerTest.java
@@ -171,6 +171,24 @@ class SortingSessionManagerTest {
   }
 
   @Test
+  @DisplayName("skip mid-run resets to sorted before the next algorithm's shuffle")
+  void skipResetsToSortedBeforeNextShuffle() {
+    arrayModel.setShuffleType(ShuffleType.REVERSE);
+    ScrambleThenWaitAlgorithm first = new ScrambleThenWaitAlgorithm(arrayModel);
+    CaptureStartAlgorithm second = new CaptureStartAlgorithm(arrayModel);
+    stateManager.setRunning(true);
+
+    sessionManager.startSortingSession(List.of(first, second));
+
+    awaitUntilRunning(first);
+    sessionManager.skipCurrent();
+    sessionManager.waitForCompletion();
+
+    // Reverse of identity [0,1,2,3,4] — not reverse of the scrambled mid-skip state.
+    assertArrayEquals(new int[] {4, 3, 2, 1, 0}, second.startSnapshot());
+  }
+
+  @Test
   @DisplayName("cancel mid-run stops execution and clears running state")
   void cancelMidRunStopsExecution() {
     UntilCancelledAlgorithm algorithm = new UntilCancelledAlgorithm(arrayModel);
@@ -233,6 +251,14 @@ class SortingSessionManagerTest {
   }
 
   private static void awaitUntilRunning(UntilCancelledAlgorithm algorithm) {
+    long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(500);
+    while (!algorithm.isRunning() && System.nanoTime() < deadline) {
+      Thread.onSpinWait();
+    }
+    assertTrue(algorithm.isRunning(), "algorithm thread should have entered sort()");
+  }
+
+  private static void awaitUntilRunning(ScrambleThenWaitAlgorithm algorithm) {
     long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(500);
     while (!algorithm.isRunning() && System.nanoTime() < deadline) {
       Thread.onSpinWait();
@@ -324,6 +350,64 @@ class SortingSessionManagerTest {
       report(name);
       while (!isCancelled()) {
         Thread.onSpinWait();
+      }
+    }
+  }
+
+  /** Leaves a non-identity permutation, then waits so Skip can abort mid-run. */
+  private static class ScrambleThenWaitAlgorithm extends SortingAlgorithm {
+    private final ArrayModel model;
+    private volatile boolean running;
+
+    ScrambleThenWaitAlgorithm(ArrayModel arrayModel) {
+      super(arrayModel, NO_OP_PROCESSING);
+      model = arrayModel;
+      name = "ScrambleThenWait";
+      setDelay(false);
+    }
+
+    boolean isRunning() {
+      return running;
+    }
+
+    @Override
+    public void sort() {
+      report(name);
+      // Distinct from identity and from reverse(identity): reverse of this is {3,4,2,1,0}.
+      model.set(0, 0);
+      model.set(1, 1);
+      model.set(2, 2);
+      model.set(3, 4);
+      model.set(4, 3);
+      running = true;
+      while (!isCancelled()) {
+        Thread.onSpinWait();
+      }
+    }
+  }
+
+  /** Records the array at the start of {@link #sort()} (after prepare/shuffle). */
+  private static class CaptureStartAlgorithm extends SortingAlgorithm {
+    private final ArrayModel model;
+    private int[] startSnapshot = new int[0];
+
+    CaptureStartAlgorithm(ArrayModel arrayModel) {
+      super(arrayModel, NO_OP_PROCESSING);
+      model = arrayModel;
+      name = "CaptureStart";
+      setDelay(false);
+    }
+
+    int[] startSnapshot() {
+      return startSnapshot;
+    }
+
+    @Override
+    public void sort() {
+      report(name);
+      startSnapshot = model.getArray().clone();
+      for (int i = 0; i < model.getLength(); i++) {
+        model.set(i, i);
       }
     }
   }

--- a/src/test/java/io/github/compilerstuck/control/shuffle/RecordedShuffleTest.java
+++ b/src/test/java/io/github/compilerstuck/control/shuffle/RecordedShuffleTest.java
@@ -1,0 +1,52 @@
+package io.github.compilerstuck.control.shuffle;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.compilerstuck.control.config.ShuffleType;
+import io.github.compilerstuck.control.model.ArrayController;
+import io.github.compilerstuck.control.model.OperationReporter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RecordedShuffleTest {
+
+  @Test
+  @DisplayName("mute capture then replay ends on the same permutation")
+  void captureAndReplayRoundTrip() {
+    ArrayController array = new ArrayController(64);
+    array.setShuffleType(ShuffleType.RANDOM);
+    array.setDelayContext(() -> {});
+    array.setOperationReporter(OperationReporter.NOOP);
+
+    int[] identity = array.getArray().clone();
+    RecordedShuffle recorded = array.captureMuteShuffle();
+    int[] afterMute = recorded.post();
+
+    assertEquals(identity.length, afterMute.length);
+    // Mute shuffle should have changed a random array (extremely likely for n=64).
+    assertTrue(recorded.swapCount() > 0);
+
+    array.restoreContents(identity);
+    array.replayRecordedShuffle(recorded);
+    assertArrayEquals(afterMute, array.getArray());
+  }
+
+  @Test
+  @DisplayName("sorted shuffle records no swaps and replay restores post state")
+  void sortedCaptureHasNoSwaps() {
+    ArrayController array = new ArrayController(16);
+    array.setShuffleType(ShuffleType.SORTED);
+    array.setDelayContext(() -> {});
+    array.setOperationReporter(OperationReporter.NOOP);
+
+    int[] before = array.getArray().clone();
+    RecordedShuffle recorded = array.captureMuteShuffle();
+    assertEquals(0, recorded.swapCount());
+    assertArrayEquals(before, recorded.post());
+
+    array.replayRecordedShuffle(recorded);
+    assertArrayEquals(before, array.getArray());
+  }
+}

--- a/src/test/java/io/github/compilerstuck/sortingalgorithms/SortingAlgorithmDelayStrideTest.java
+++ b/src/test/java/io/github/compilerstuck/sortingalgorithms/SortingAlgorithmDelayStrideTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.github.compilerstuck.control.model.ArrayController;
 import io.github.compilerstuck.control.render.CountingDelayContext;
+import io.github.compilerstuck.visual.Marker;
 import org.junit.jupiter.api.Test;
 
 class SortingAlgorithmDelayStrideTest {
@@ -33,6 +34,27 @@ class SortingAlgorithmDelayStrideTest {
     assertEquals(11, counter.stepCount());
   }
 
+  @Test
+  void paceReplacesPreviousMarkersInsteadOfAccumulating() {
+    ArrayController array = new ArrayController(8);
+    CountingDelayContext counter = new CountingDelayContext();
+    MarkerProbe probe = new MarkerProbe(array);
+    probe.setDelayContext(counter);
+    probe.setDelayStride(1);
+    probe.sort();
+    int setCount = 0;
+    for (int i = 0; i < array.getLength(); i++) {
+      if (array.getMarker(i) == Marker.SET) {
+        setCount++;
+      }
+    }
+    assertEquals(2, setCount);
+    assertEquals(Marker.SET, array.getMarker(6));
+    assertEquals(Marker.SET, array.getMarker(7));
+    assertEquals(Marker.NORMAL, array.getMarker(0));
+    assertEquals(Marker.NORMAL, array.getMarker(1));
+  }
+
   private static final class StrideProbe extends SortingAlgorithm {
     private final int calls;
 
@@ -47,6 +69,20 @@ class SortingAlgorithmDelayStrideTest {
       for (int i = 0; i < calls && !isCancelled(); i++) {
         delay();
       }
+    }
+  }
+
+  private static final class MarkerProbe extends SortingAlgorithm {
+    MarkerProbe(ArrayController model) {
+      super(model);
+      this.name = "MarkerProbe";
+    }
+
+    @Override
+    public void sort() {
+      delay(new int[] {0, 1});
+      delay(new int[] {2, 3});
+      delay(new int[] {6, 7});
     }
   }
 }


### PR DESCRIPTION
## Summary
- Hide equalize **Prepare..** by mute-recording the shuffle, dry-running on a clone in parallel, and covering with a paced shuffle replay
- Fast-forward (no FrameGate waits, live updates + audio) when large-n work cannot finish near the slider target responsively
- Fix pace marker accumulation (all-white bars) and reset to the sorted identity before the next shuffle after **Skip**

## Test plan
- [ ] Run-all with equalize on: Bubble/Shaker/Merge at large n — no Prepare HUD on the happy path; shuffle still ~1.5s
- [ ] Shaker/Bubble at large n + short target: fast-forward completes with sound and only current-step highlights (not all-white)
- [ ] Skip mid-sort: next algorithm’s shuffle starts from the full sorted array
- [ ] `./mvnw -Dtest=EqualizeSortDurationSessionTest,SortingSessionManagerTest,RecordedShuffleTest,SortingAlgorithmDelayStrideTest test`