### PR TITLE
fix Morphing Shell size scaling and audio defaults

### DIFF
--- a/src/main/java/io/github/compilerstuck/control/config/audio/AudioSettings.java
+++ b/src/main/java/io/github/compilerstuck/control/config/audio/AudioSettings.java
@@ -40,7 +40,7 @@ public record AudioSettings(
   public static final int DEFAULT_PAN = 64;
   public static final int DEFAULT_LOW_NOTE = 28;
   public static final int DEFAULT_HIGH_NOTE = 68;
-  public static final int DEFAULT_REVERB = 0;
+  public static final int DEFAULT_REVERB = 31;
   public static final int DEFAULT_CHORUS = 0;
   public static final int DEFAULT_ATTACK_TIME = 64;
   public static final int DEFAULT_RELEASE_TIME = 64;

--- a/src/main/java/io/github/compilerstuck/visual/MorphingShell.java
+++ b/src/main/java/io/github/compilerstuck/visual/MorphingShell.java
@@ -136,7 +136,9 @@ public class MorphingShell extends Visualization implements ConfigurableVisualiz
     int colCnt = 0;
     for (int i = 0; i < length; i++) {
       int markerIndex = rowCnt + colCnt * colSize;
-      double barHeight = arrayModel.get(markerIndex);
+      // Map values into [0, screenWidth] so X extent stays screen-relative (not N-dependent).
+      // Legacy raw values only looked right near N≈screenWidth (~2000).
+      float barHeight = screenWidth * arrayModel.get(markerIndex) / (float) length;
 
       float sinLon = sinAa * lonCos[i] + cosAa * lonSin[i];
       float cosLon = cosAa * lonCos[i] - sinAa * lonSin[i];
@@ -145,7 +147,7 @@ public class MorphingShell extends Visualization implements ConfigurableVisualiz
 
       float z = radiusThird * sinLon * cosLat;
       float x = radius * sinLon * sinLat;
-      float y = (float) (radius * cosLon + barHeight);
+      float y = radius * cosLon + barHeight;
 
       // Legacy Processing pos (W/4 + y/2, H/2 + x/2, centerZ+z) → world
       float wx = y / 2f - halfW * 0.5f;

--- a/src/test/java/io/github/compilerstuck/control/config/audio/AudioSettingsTest.java
+++ b/src/test/java/io/github/compilerstuck/control/config/audio/AudioSettingsTest.java
@@ -10,9 +10,16 @@ class AudioSettingsTest {
   void defaultsMatchCurrentHardcodedBehavior() {
     AudioSettings d = AudioSettings.defaults();
     assertEquals(4, d.instrumentProgram());
+    assertEquals(100, d.volume());
     assertEquals(90, d.velocity());
+    assertEquals(64, d.pan());
     assertEquals(28, d.lowNote());
     assertEquals(68, d.highNote());
+    assertEquals(31, d.reverb());
+    assertEquals(0, d.chorus());
+    assertEquals(64, d.attackTime());
+    assertEquals(64, d.releaseTime());
+    assertEquals(64, d.brightness());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Scale Morphing Shell morph offset by `screenWidth / length` so world-X extent no longer grows with array size
- Set default reverb to 31 and expand AudioSettings defaults coverage in tests

## Test plan
- [ ] Open **3D - Morphing Shell** and compare array sizes ~500, ~2000, and ~8000 — shell width should stay similar
- [ ] Confirm audio defaults load with reverb 31
- [ ] `./mvnw --batch-mode test -Dtest=AudioSettingsTest`