### PR TITLE
perf: optimize render packing and visual allocations

### DIFF
--- a/src/main/java/io/github/compilerstuck/visual/ColorGradientGraph.java
+++ b/src/main/java/io/github/compilerstuck/visual/ColorGradientGraph.java
@@ -17,6 +17,8 @@ public class ColorGradientGraph extends Visualization implements ConfigurableVis
 
   private float[] xywh;
   private int[] argb;
+  private float[] div;
+  private int[] divArgb;
 
   public ColorGradientGraph(
       ArrayModel arrayModel, ColorGradient colorGradient, Sound sound, RenderSystem rs) {
@@ -70,8 +72,10 @@ public class ColorGradientGraph extends Visualization implements ConfigurableVis
     rs.fillRects(xywh, argb, length);
 
     if (settings.showIndexDividers() && length > 1) {
-      float[] div = new float[Math.max(4, (length - 1) * 4)];
-      int[] divArgb = new int[Math.max(1, length - 1)];
+      if (div == null || div.length < (length - 1) * 4) {
+        div = new float[(length - 1) * 4];
+        divArgb = new int[length - 1];
+      }
       for (int i = 1; i < length; i++) {
         float x = i * slotWidth;
         int o = (i - 1) * 4;

--- a/src/main/java/io/github/compilerstuck/visual/DisparityChords.java
+++ b/src/main/java/io/github/compilerstuck/visual/DisparityChords.java
@@ -7,7 +7,6 @@ import io.github.compilerstuck.control.render.CoordinateSpace;
 import io.github.compilerstuck.control.render.RenderSystem;
 import io.github.compilerstuck.sound.Sound;
 import io.github.compilerstuck.visual.gradient.ColorGradient;
-import java.awt.Color;
 
 public class DisparityChords extends Visualization implements ConfigurableVisualization {
 
@@ -26,6 +25,17 @@ public class DisparityChords extends Visualization implements ConfigurableVisual
   private int[] lineArgb;
   private float[] ellipseXywh;
   private int[] ellipseArgb;
+  private int lineCount;
+  private int ellipseCount;
+
+  private long cachedRevision = Long.MIN_VALUE;
+  private int cachedWidth = -1;
+  private int cachedHeight = -1;
+  private int cachedLength = -1;
+  private int cachedRadius = -1;
+  private int cachedOpacity = -1;
+  private double cachedMarkerSize = Double.NaN;
+  private ColorGradient cachedGradient;
 
   public DisparityChords(
       ArrayModel arrayModel, ColorGradient colorGradient, Sound sound, RenderSystem rs) {
@@ -43,6 +53,7 @@ public class DisparityChords extends Visualization implements ConfigurableVisual
     if (next instanceof DisparityChordsSettings s) {
       settings = s;
       cacheLength = -1;
+      cachedRevision = Long.MIN_VALUE;
     }
   }
 
@@ -77,15 +88,20 @@ public class DisparityChords extends Visualization implements ConfigurableVisual
     }
   }
 
-  @Override
-  public void update(float delta) {
-    int length = arrayModel.getLength();
-    DisparityChordsSettings s = settings;
-    radius = (int) (Math.min(screenHeight, screenWidth) * s.radiusScale());
-    int centerX = screenWidth / 2;
-    int centerY = screenHeight / 2;
-
-    rebuildRingPositions(length, radius, centerX, centerY);
+  private void ensurePacked(int length, int radius, DisparityChordsSettings s) {
+    long rev = arrayModel.getVisualRevision();
+    int opacity = s.chordOpacity();
+    double markerSize = s.coincidentMarkerSize();
+    if (cachedRevision == rev
+        && cachedWidth == screenWidth
+        && cachedHeight == screenHeight
+        && cachedLength == length
+        && cachedRadius == radius
+        && cachedOpacity == opacity
+        && cachedMarkerSize == markerSize
+        && cachedGradient == colorGradient) {
+      return;
+    }
 
     if (xyxy == null || xyxy.length < length * 4) {
       xyxy = new float[length * 4];
@@ -94,13 +110,13 @@ public class DisparityChords extends Visualization implements ConfigurableVisual
       ellipseArgb = new int[length];
     }
 
-    int lineCount = 0;
-    int ellipseCount = 0;
+    lineCount = 0;
+    ellipseCount = 0;
+    float marker = (float) markerSize;
 
     for (int i = 0; i < length; i++) {
       int value = arrayModel.get(i);
-      Color color = colorGradient.getMarkerColor(value, arrayModel.getMarker(i));
-      int rgb = color.getRGB();
+      int rgb = colorGradient.getMarkerArgb(value, arrayModel.getMarker(i));
 
       if (arrayModel.getMarker(i) == Marker.SET) {
         sound.playSound(i);
@@ -115,10 +131,9 @@ public class DisparityChords extends Visualization implements ConfigurableVisual
         int o = ellipseCount * 4;
         ellipseXywh[o] = x;
         ellipseXywh[o + 1] = y;
-        float marker = (float) s.coincidentMarkerSize();
         ellipseXywh[o + 2] = marker;
         ellipseXywh[o + 3] = marker;
-        ellipseArgb[ellipseCount] = VisColors.withAlpha(rgb, s.chordOpacity());
+        ellipseArgb[ellipseCount] = VisColors.withAlpha(rgb, opacity);
         ellipseCount++;
       } else {
         int o = lineCount * 4;
@@ -126,10 +141,32 @@ public class DisparityChords extends Visualization implements ConfigurableVisual
         xyxy[o + 1] = y;
         xyxy[o + 2] = x2;
         xyxy[o + 3] = y2;
-        lineArgb[lineCount] = VisColors.withAlpha(rgb, s.chordOpacity());
+        lineArgb[lineCount] = VisColors.withAlpha(rgb, opacity);
         lineCount++;
       }
     }
+
+    cachedRevision = rev;
+    cachedWidth = screenWidth;
+    cachedHeight = screenHeight;
+    cachedLength = length;
+    cachedRadius = radius;
+    cachedOpacity = opacity;
+    cachedMarkerSize = markerSize;
+    cachedGradient = colorGradient;
+  }
+
+  @Override
+  public void update(float delta) {
+    int length = arrayModel.getLength();
+    DisparityChordsSettings s = settings;
+    radius = (int) (Math.min(screenHeight, screenWidth) * s.radiusScale());
+    int centerX = screenWidth / 2;
+    int centerY = screenHeight / 2;
+
+    rebuildRingPositions(length, radius, centerX, centerY);
+    ensurePacked(length, radius, s);
+
     rs.strokeWeight((float) s.lineThickness());
     rs.strokeLines(xyxy, lineArgb, lineCount);
     rs.strokeEllipses(ellipseXywh, ellipseArgb, ellipseCount);

--- a/src/main/java/io/github/compilerstuck/visual/DisparitySphereHoops.java
+++ b/src/main/java/io/github/compilerstuck/visual/DisparitySphereHoops.java
@@ -7,13 +7,25 @@ import io.github.compilerstuck.control.render.CoordinateSpace;
 import io.github.compilerstuck.control.render.RenderSystem;
 import io.github.compilerstuck.sound.Sound;
 import io.github.compilerstuck.visual.gradient.ColorGradient;
-import java.awt.Color;
 
 public class DisparitySphereHoops extends Visualization implements ConfigurableVisualization {
 
   private volatile DisparitySphereHoopsSettings settings = DisparitySphereHoopsSettings.defaults();
 
   private static final int SEGMENTS = 48;
+
+  /** cos/sin of {@code t = 2π·seg/SEGMENTS}; identical for every hoop, so computed once. */
+  private static final float[] SEG_COS = new float[SEGMENTS + 1];
+
+  private static final float[] SEG_SIN = new float[SEGMENTS + 1];
+
+  static {
+    for (int seg = 0; seg <= SEGMENTS; seg++) {
+      float t = (float) (2 * Math.PI * seg / SEGMENTS);
+      SEG_COS[seg] = (float) Math.cos(t);
+      SEG_SIN[seg] = (float) Math.sin(t);
+    }
+  }
 
   private float[] wiBase;
   private float[] zOffsets;
@@ -28,9 +40,17 @@ public class DisparitySphereHoops extends Visualization implements ConfigurableV
   private int cachedLength = -1;
   private int cachedRadius = -1;
   private ColorGradient cachedGradient;
+  private boolean dataDirty = true;
 
   private float[] xyzxyz;
   private int[] lineArgb;
+  private int lineCount;
+
+  private long linesRevision = Long.MIN_VALUE;
+  private int linesWidth = -1;
+  private int linesHeight = -1;
+  private int linesLength = -1;
+  private int linesRadius = -1;
 
   public DisparitySphereHoops(
       ArrayModel arrayModel, ColorGradient colorGradient, Sound sound, RenderSystem rs) {
@@ -47,6 +67,8 @@ public class DisparitySphereHoops extends Visualization implements ConfigurableV
   public void applySettings(VisualizationSettings next) {
     if (next instanceof DisparitySphereHoopsSettings s) {
       settings = s;
+      cachedRevision = Long.MIN_VALUE;
+      dataDirty = true;
     }
   }
 
@@ -71,6 +93,7 @@ public class DisparitySphereHoops extends Visualization implements ConfigurableV
       wiBase[i] = (float) Math.sqrt(1 - Math.pow((float) i / length * 2 - 1, 2));
       zOffsets[i] = radius / 2f - VisMath.map(i, 0, length, 0, radius);
     }
+    dataDirty = true;
   }
 
   private void ensureSphereWiAndColors(int length, int radius) {
@@ -85,17 +108,9 @@ public class DisparitySphereHoops extends Visualization implements ConfigurableV
     }
     for (int i = 0; i < length; i++) {
       int value = arrayModel.get(i);
-      Color color = colorGradient.getMarkerColor(value, arrayModel.getMarker(i));
 
       float barHeight =
-          -(float)
-              (1f
-                  / length
-                  * (length
-                      - 2
-                          * Math.min(
-                              Math.min(Math.abs(i - value), Math.abs(i - length - value)),
-                              Math.abs(i + length - value))));
+          -(float) (1f / length * (length - 2 * VisMath.circularDistance(i, value, length)));
       float wi = wiBase[i] * barHeight;
       sphereWi[i] = (int) VisMath.map(wi, 0, 1, 0, radius);
 
@@ -103,7 +118,7 @@ public class DisparitySphereHoops extends Visualization implements ConfigurableV
         sound.playSound(i);
       }
 
-      colorsRgb[i] = color.getRGB();
+      colorsRgb[i] = colorGradient.getMarkerArgb(value, arrayModel.getMarker(i));
     }
     cachedRevision = rev;
     cachedWidth = screenWidth;
@@ -111,41 +126,38 @@ public class DisparitySphereHoops extends Visualization implements ConfigurableV
     cachedLength = length;
     cachedRadius = radius;
     cachedGradient = colorGradient;
+    dataDirty = true;
   }
 
-  @Override
-  public void update(float delta) {
-    DisparitySphereHoopsSettings s = settings;
-    int screenMin = Math.min(screenHeight, screenWidth);
-    int radius = (int) (screenMin * s.globeScale());
-    int length = arrayModel.getLength();
-    float centerZ = -(int) (screenMin / 10);
-    float centerX = (float) screenWidth / 2;
-    float centerY = (float) screenHeight / 2;
+  private boolean linesNeedRebuild(int length, int radius) {
+    return dataDirty
+        || linesRevision != cachedRevision
+        || linesWidth != screenWidth
+        || linesHeight != screenHeight
+        || linesLength != length
+        || linesRadius != radius
+        || xyzxyz == null;
+  }
 
-    rebuildGeometry(length, radius);
-    ensureSphereWiAndColors(length, radius);
-
-    float rotX = VisMath.PI / 3;
-    float cosX = (float) Math.cos(rotX);
-    float sinX = (float) Math.sin(rotX);
-
+  private void rebuildLines(int length, int radius, float centerX, float centerY, float centerZ) {
     int maxLines = length * SEGMENTS;
     if (xyzxyz == null || xyzxyz.length < maxLines * 6) {
       xyzxyz = new float[maxLines * 6];
       lineArgb = new int[maxLines];
     }
 
-    int lineCount = 0;
+    float cosX = VisMath.COS_ROT_X_PI_3;
+    float sinX = VisMath.SIN_ROT_X_PI_3;
+
+    lineCount = 0;
     for (int i = 0; i < length; i++) {
       float w = sphereWi[i];
       float zLocal = zOffsets[i];
       int rgb = colorsRgb[i];
       float prevX = 0, prevY = 0, prevZ = 0;
       for (int seg = 0; seg <= SEGMENTS; seg++) {
-        float t = (float) (2 * Math.PI * seg / SEGMENTS);
-        float lx = (w * 0.5f) * (float) Math.cos(t);
-        float ly = (w * 0.5f) * (float) Math.sin(t);
+        float lx = (w * 0.5f) * SEG_COS[seg];
+        float ly = (w * 0.5f) * SEG_SIN[seg];
         float lz = zLocal;
         float y2 = cosX * ly - sinX * lz;
         float z2 = sinX * ly + cosX * lz;
@@ -167,6 +179,29 @@ public class DisparitySphereHoops extends Visualization implements ConfigurableV
         prevY = wy;
         prevZ = wz;
       }
+    }
+    linesRevision = cachedRevision;
+    linesWidth = screenWidth;
+    linesHeight = screenHeight;
+    linesLength = length;
+    linesRadius = radius;
+    dataDirty = false;
+  }
+
+  @Override
+  public void update(float delta) {
+    DisparitySphereHoopsSettings s = settings;
+    int screenMin = Math.min(screenHeight, screenWidth);
+    int radius = (int) (screenMin * s.globeScale());
+    int length = arrayModel.getLength();
+    float centerZ = -(int) (screenMin / 10);
+    float centerX = (float) screenWidth / 2;
+    float centerY = (float) screenHeight / 2;
+
+    rebuildGeometry(length, radius);
+    ensureSphereWiAndColors(length, radius);
+    if (linesNeedRebuild(length, radius)) {
+      rebuildLines(length, radius, centerX, centerY, centerZ);
     }
 
     rs.begin3D();

--- a/src/main/java/io/github/compilerstuck/visual/Hoops.java
+++ b/src/main/java/io/github/compilerstuck/visual/Hoops.java
@@ -7,7 +7,6 @@ import io.github.compilerstuck.control.render.CoordinateSpace;
 import io.github.compilerstuck.control.render.RenderSystem;
 import io.github.compilerstuck.sound.Sound;
 import io.github.compilerstuck.visual.gradient.ColorGradient;
-import java.awt.Color;
 
 public class Hoops extends Visualization implements ConfigurableVisualization {
 
@@ -20,6 +19,15 @@ public class Hoops extends Visualization implements ConfigurableVisualization {
   private int cacheMaxRadius = -1;
   private float[] xywh;
   private int[] argb;
+
+  private long cachedRevision = Long.MIN_VALUE;
+  private int cachedWidth = -1;
+  private int cachedHeight = -1;
+  private int cachedN = -1;
+  private int cachedCenterX = -1;
+  private int cachedCenterY = -1;
+  private int cachedMaxRadius = -1;
+  private ColorGradient cachedGradient;
 
   public Hoops(ArrayModel arrayModel, ColorGradient colorGradient, Sound sound, RenderSystem rs) {
     super(arrayModel, colorGradient, sound, rs);
@@ -36,6 +44,7 @@ public class Hoops extends Visualization implements ConfigurableVisualization {
     if (next instanceof HoopsSettings s) {
       settings = s;
       cacheLength = -1;
+      cachedRevision = Long.MIN_VALUE;
     }
   }
 
@@ -58,6 +67,44 @@ public class Hoops extends Visualization implements ConfigurableVisualization {
     }
   }
 
+  private void ensurePacked(int length, int maxRadius, int centerX, int centerY) {
+    long rev = arrayModel.getVisualRevision();
+    if (cachedRevision == rev
+        && cachedWidth == screenWidth
+        && cachedHeight == screenHeight
+        && cachedN == length
+        && cachedCenterX == centerX
+        && cachedCenterY == centerY
+        && cachedMaxRadius == maxRadius
+        && cachedGradient == colorGradient) {
+      return;
+    }
+    if (xywh == null || xywh.length < length * 4) {
+      xywh = new float[length * 4];
+      argb = new int[length];
+    }
+    for (int i = 0; i < length; i++) {
+      if (arrayModel.getMarker(i) == Marker.SET) {
+        sound.playSound(i);
+      }
+      radius = radii[i];
+      int o = i * 4;
+      xywh[o] = centerX;
+      xywh[o + 1] = centerY;
+      xywh[o + 2] = radius;
+      xywh[o + 3] = radius;
+      argb[i] = colorGradient.getMarkerArgb(arrayModel.get(i), arrayModel.getMarker(i));
+    }
+    cachedRevision = rev;
+    cachedWidth = screenWidth;
+    cachedHeight = screenHeight;
+    cachedN = length;
+    cachedCenterX = centerX;
+    cachedCenterY = centerY;
+    cachedMaxRadius = maxRadius;
+    cachedGradient = colorGradient;
+  }
+
   @Override
   public void update(float delta) {
     HoopsSettings s = settings;
@@ -66,29 +113,9 @@ public class Hoops extends Visualization implements ConfigurableVisualization {
     int centerX = screenWidth / 2;
     int centerY = screenHeight / 2;
     rebuildRadii(length, maxRadius);
-
-    if (xywh == null || xywh.length < length * 4) {
-      xywh = new float[length * 4];
-      argb = new int[length];
-    }
+    ensurePacked(length, maxRadius, centerX, centerY);
 
     rs.strokeWeight(0.5f);
-
-    for (int i = 0; i < length; i++) {
-      Color color = colorGradient.getMarkerColor(arrayModel.get(i), arrayModel.getMarker(i));
-
-      if (arrayModel.getMarker(i) == Marker.SET) {
-        sound.playSound(i);
-      }
-
-      radius = radii[i];
-      int o = i * 4;
-      xywh[o] = centerX;
-      xywh[o + 1] = centerY;
-      xywh[o + 2] = radius;
-      xywh[o + 3] = radius;
-      argb[i] = color.getRGB();
-    }
     rs.strokeEllipses(xywh, argb, length);
   }
 }

--- a/src/main/java/io/github/compilerstuck/visual/MosaicSquares.java
+++ b/src/main/java/io/github/compilerstuck/visual/MosaicSquares.java
@@ -9,7 +9,6 @@ import io.github.compilerstuck.control.render.CoordinateSpace;
 import io.github.compilerstuck.control.render.RenderSystem;
 import io.github.compilerstuck.sound.Sound;
 import io.github.compilerstuck.visual.gradient.ColorGradient;
-import java.awt.Color;
 
 public class MosaicSquares extends Visualization implements ConfigurableVisualization {
 
@@ -25,6 +24,13 @@ public class MosaicSquares extends Visualization implements ConfigurableVisualiz
   private float cachedTileDimY;
   private float[] xywh;
   private int[] argb;
+
+  private long packedRevision = Long.MIN_VALUE;
+  private int packedWidth = -1;
+  private int packedHeight = -1;
+  private int packedDrawCount = -1;
+  private double packedGap = Double.NaN;
+  private ColorGradient packedGradient;
 
   public MosaicSquares(
       ArrayModel arrayModel, ColorGradient colorGradient, Sound sound, RenderSystem rs) {
@@ -42,6 +48,7 @@ public class MosaicSquares extends Visualization implements ConfigurableVisualiz
     if (next instanceof MosaicSquaresSettings s) {
       settings = s;
       cachedDrawCount = -1;
+      packedRevision = Long.MIN_VALUE;
     }
   }
 
@@ -73,6 +80,42 @@ public class MosaicSquares extends Visualization implements ConfigurableVisualiz
     cachedHeight = screenHeight;
   }
 
+  private void ensurePacked(int drawCount, float gap) {
+    long rev = arrayModel.getVisualRevision();
+    if (packedRevision == rev
+        && packedWidth == screenWidth
+        && packedHeight == screenHeight
+        && packedDrawCount == drawCount
+        && packedGap == gap
+        && packedGradient == colorGradient) {
+      return;
+    }
+    if (xywh == null || xywh.length < drawCount * 4) {
+      xywh = new float[drawCount * 4];
+      argb = new int[drawCount];
+    }
+    float inset = gap * 0.5f;
+    float w = Math.max(0.5f, cachedTileDimX - gap);
+    float h = Math.max(0.5f, cachedTileDimY - gap);
+    for (int i = 0; i < drawCount; i++) {
+      if (arrayModel.getMarker(i) == Marker.SET) {
+        sound.playSound(i);
+      }
+      int o = i * 4;
+      xywh[o] = tileX[i] + inset;
+      xywh[o + 1] = tileY[i] + inset;
+      xywh[o + 2] = w;
+      xywh[o + 3] = h;
+      argb[i] = colorGradient.getMarkerArgb(arrayModel.get(i), arrayModel.getMarker(i));
+    }
+    packedRevision = rev;
+    packedWidth = screenWidth;
+    packedHeight = screenHeight;
+    packedDrawCount = drawCount;
+    packedGap = gap;
+    packedGradient = colorGradient;
+  }
+
   @Override
   public void update(float delta) {
     int nextN = (int) floor(Math.pow(arrayModel.getLength(), 1 / 2.) + 0.1);
@@ -80,29 +123,7 @@ public class MosaicSquares extends Visualization implements ConfigurableVisualiz
     int drawCount = Math.min(arrayModel.getLength(), nextN * nextN);
 
     ensureTileOrigins(drawCount, nextN, squareRoot);
-
-    if (xywh == null || xywh.length < drawCount * 4) {
-      xywh = new float[drawCount * 4];
-      argb = new int[drawCount];
-    }
-
-    for (int i = 0; i < drawCount; i++) {
-      Color color = colorGradient.getMarkerColor(arrayModel.get(i), arrayModel.getMarker(i));
-
-      if (arrayModel.getMarker(i) == Marker.SET) {
-        sound.playSound(i);
-      }
-
-      MosaicSquaresSettings s = settings;
-      float gap = (float) s.tileGapPx();
-      float inset = gap * 0.5f;
-      int o = i * 4;
-      xywh[o] = tileX[i] + inset;
-      xywh[o + 1] = tileY[i] + inset;
-      xywh[o + 2] = Math.max(0.5f, cachedTileDimX - gap);
-      xywh[o + 3] = Math.max(0.5f, cachedTileDimY - gap);
-      argb[i] = color.getRGB();
-    }
+    ensurePacked(drawCount, (float) settings.tileGapPx());
     rs.fillRects(xywh, argb, drawCount);
   }
 }

--- a/src/main/java/io/github/compilerstuck/visual/NumberPlot.java
+++ b/src/main/java/io/github/compilerstuck/visual/NumberPlot.java
@@ -17,10 +17,12 @@ public class NumberPlot extends Visualization implements ConfigurableVisualizati
   private int cachedLength = -1;
   private int cachedWidth = -1;
   private int cachedHeight = -1;
+  private long cachedRevision = Long.MIN_VALUE;
   private int[] cachedValues;
   private int[] barHeights;
   private String[] labels;
   private float[] drawYs;
+  private boolean drawYsDirty = true;
 
   public NumberPlot(
       ArrayModel arrayModel, ColorGradient colorGradient, Sound sound, RenderSystem rs) {
@@ -46,8 +48,12 @@ public class NumberPlot extends Visualization implements ConfigurableVisualizati
   }
 
   private void ensureSlotCaches(int length, int heightScale) {
+    long rev = arrayModel.getVisualRevision();
     boolean layoutChanged =
         cachedLength != length || cachedWidth != screenWidth || cachedHeight != screenHeight;
+    if (!layoutChanged && cachedRevision == rev) {
+      return;
+    }
     if (layoutChanged) {
       cachedLength = length;
       cachedWidth = screenWidth;
@@ -61,6 +67,7 @@ public class NumberPlot extends Visualization implements ConfigurableVisualizati
           cachedValues[i] = Integer.MIN_VALUE;
         }
       }
+      drawYsDirty = true;
     }
     for (int i = 0; i < length; i++) {
       int value = arrayModel.get(i);
@@ -68,8 +75,20 @@ public class NumberPlot extends Visualization implements ConfigurableVisualizati
         cachedValues[i] = value;
         barHeights[i] = (value + 1) * heightScale / length;
         labels[i] = String.valueOf(value + 1);
+        drawYsDirty = true;
       }
     }
+    cachedRevision = rev;
+  }
+
+  private void ensureDrawYs(int length) {
+    if (!drawYsDirty) {
+      return;
+    }
+    for (int i = 0; i < length; i++) {
+      drawYs[i] = worldYToOverlayY(barHeights[i]);
+    }
+    drawYsDirty = false;
   }
 
   @Override
@@ -81,12 +100,12 @@ public class NumberPlot extends Visualization implements ConfigurableVisualizati
     indexXCache.ensure(length, screenWidth);
     float[] xs = indexXCache.xs();
     ensureSlotCaches(length, heightScale);
+    ensureDrawYs(length);
 
     for (int i = 0; i < length; i++) {
       if (arrayModel.getMarker(i) == Marker.SET) {
         sound.playSound(i);
       }
-      drawYs[i] = worldYToOverlayY(barHeights[i]);
     }
 
     if (length > 0) {

--- a/src/main/java/io/github/compilerstuck/visual/SphereHoops.java
+++ b/src/main/java/io/github/compilerstuck/visual/SphereHoops.java
@@ -7,13 +7,25 @@ import io.github.compilerstuck.control.render.CoordinateSpace;
 import io.github.compilerstuck.control.render.RenderSystem;
 import io.github.compilerstuck.sound.Sound;
 import io.github.compilerstuck.visual.gradient.ColorGradient;
-import java.awt.Color;
 
 public class SphereHoops extends Visualization implements ConfigurableVisualization {
 
   private volatile SphereHoopsSettings settings = SphereHoopsSettings.defaults();
 
   private static final int SEGMENTS = 48;
+
+  /** cos/sin of {@code t = 2π·seg/SEGMENTS}; identical for every hoop, so computed once. */
+  private static final float[] SEG_COS = new float[SEGMENTS + 1];
+
+  private static final float[] SEG_SIN = new float[SEGMENTS + 1];
+
+  static {
+    for (int seg = 0; seg <= SEGMENTS; seg++) {
+      float t = (float) (2 * Math.PI * seg / SEGMENTS);
+      SEG_COS[seg] = (float) Math.cos(t);
+      SEG_SIN[seg] = (float) Math.sin(t);
+    }
+  }
 
   private float[] hoopWidths;
   private float[] zOffsets;
@@ -22,6 +34,14 @@ public class SphereHoops extends Visualization implements ConfigurableVisualizat
 
   private float[] xyzxyz;
   private int[] lineArgb;
+  private int lineCount;
+
+  private long cachedRevision = Long.MIN_VALUE;
+  private int cachedWidth = -1;
+  private int cachedHeight = -1;
+  private int cachedLength = -1;
+  private int cachedRadius = -1;
+  private ColorGradient cachedGradient;
 
   public SphereHoops(
       ArrayModel arrayModel, ColorGradient colorGradient, Sound sound, RenderSystem rs) {
@@ -39,6 +59,7 @@ public class SphereHoops extends Visualization implements ConfigurableVisualizat
     if (next instanceof SphereHoopsSettings s) {
       settings = s;
       cacheLength = -1;
+      cachedRevision = Long.MIN_VALUE;
     }
   }
 
@@ -64,44 +85,40 @@ public class SphereHoops extends Visualization implements ConfigurableVisualizat
     }
   }
 
-  @Override
-  public void update(float delta) {
-    SphereHoopsSettings s = settings;
-    int screenMin = Math.min(screenHeight, screenWidth);
-    int radius = (int) (screenMin * s.globeScale());
-    int length = arrayModel.getLength();
-    float centerZ = -(int) (screenMin / 10);
-    float centerX = (float) screenWidth / 2;
-    float centerY = (float) screenHeight / 2;
+  private boolean linesNeedRebuild(int length, int radius) {
+    long rev = arrayModel.getVisualRevision();
+    return cachedRevision != rev
+        || cachedWidth != screenWidth
+        || cachedHeight != screenHeight
+        || cachedLength != length
+        || cachedRadius != radius
+        || cachedGradient != colorGradient
+        || xyzxyz == null;
+  }
 
-    rebuildGeometry(length, radius);
-
-    float rotX = VisMath.PI / 3;
-    float cosX = (float) Math.cos(rotX);
-    float sinX = (float) Math.sin(rotX);
-
+  private void rebuildLines(int length, int radius, float centerX, float centerY, float centerZ) {
     int maxLines = length * SEGMENTS;
     if (xyzxyz == null || xyzxyz.length < maxLines * 6) {
       xyzxyz = new float[maxLines * 6];
       lineArgb = new int[maxLines];
     }
 
-    int lineCount = 0;
-    for (int i = 0; i < length; i++) {
-      Color color = colorGradient.getMarkerColor(arrayModel.get(i), arrayModel.getMarker(i));
+    float cosX = VisMath.COS_ROT_X_PI_3;
+    float sinX = VisMath.SIN_ROT_X_PI_3;
 
+    lineCount = 0;
+    for (int i = 0; i < length; i++) {
       if (arrayModel.getMarker(i) == Marker.SET) {
         sound.playSound(i);
       }
 
       float w = hoopWidths[i];
       float zLocal = zOffsets[i];
-      int rgb = color.getRGB();
+      int rgb = colorGradient.getMarkerArgb(arrayModel.get(i), arrayModel.getMarker(i));
       float prevX = 0, prevY = 0, prevZ = 0;
       for (int seg = 0; seg <= SEGMENTS; seg++) {
-        float t = (float) (2 * Math.PI * seg / SEGMENTS);
-        float lx = (w * 0.5f) * (float) Math.cos(t);
-        float ly = (w * 0.5f) * (float) Math.sin(t);
+        float lx = (w * 0.5f) * SEG_COS[seg];
+        float ly = (w * 0.5f) * SEG_SIN[seg];
         float lz = zLocal;
         // rotateX then translate to center
         float y2 = cosX * ly - sinX * lz;
@@ -124,6 +141,28 @@ public class SphereHoops extends Visualization implements ConfigurableVisualizat
         prevY = wy;
         prevZ = wz;
       }
+    }
+    cachedRevision = arrayModel.getVisualRevision();
+    cachedWidth = screenWidth;
+    cachedHeight = screenHeight;
+    cachedLength = length;
+    cachedRadius = radius;
+    cachedGradient = colorGradient;
+  }
+
+  @Override
+  public void update(float delta) {
+    SphereHoopsSettings s = settings;
+    int screenMin = Math.min(screenHeight, screenWidth);
+    int radius = (int) (screenMin * s.globeScale());
+    int length = arrayModel.getLength();
+    float centerZ = -(int) (screenMin / 10);
+    float centerX = (float) screenWidth / 2;
+    float centerY = (float) screenHeight / 2;
+
+    rebuildGeometry(length, radius);
+    if (linesNeedRebuild(length, radius)) {
+      rebuildLines(length, radius, centerX, centerY, centerZ);
     }
 
     rs.begin3D();

--- a/src/main/java/io/github/compilerstuck/visual/VisMath.java
+++ b/src/main/java/io/github/compilerstuck/visual/VisMath.java
@@ -6,6 +6,14 @@ public final class VisMath {
   private VisMath() {}
 
   public static final float PI = (float) Math.PI;
+
+  /** Fixed tilt used by several 3D visuals ({@code PI/3}). */
+  public static final float ROT_X_PI_3 = PI / 3f;
+
+  public static final float COS_ROT_X_PI_3 = (float) Math.cos(ROT_X_PI_3);
+
+  public static final float SIN_ROT_X_PI_3 = (float) Math.sin(ROT_X_PI_3);
+
   private static final float DEG_TO_RAD = PI / 180f;
 
   /** Linear map from one range into another (Processing {@code map} semantics). */
@@ -19,5 +27,14 @@ public final class VisMath {
 
   public static float radians(float degrees) {
     return degrees * DEG_TO_RAD;
+  }
+
+  /**
+   * Circular distance on {@code [0, length)} between index {@code i} and value {@code value}, as
+   * used by disparity visuals: {@code min(|i-v|, |i-length-v|, |i+length-v|)}.
+   */
+  public static int circularDistance(int i, int value, int length) {
+    return Math.min(
+        Math.min(Math.abs(i - value), Math.abs(i - length - value)), Math.abs(i + length - value));
   }
 }

--- a/src/main/java/io/github/compilerstuck/visual/gradient/ColorGradient.java
+++ b/src/main/java/io/github/compilerstuck/visual/gradient/ColorGradient.java
@@ -14,6 +14,9 @@ public class ColorGradient {
   private final String name;
   protected Color[] colorGradient;
 
+  /** Parallel ARGB LUT for {@link #getMarkerArgb}; rebuilt with {@link #colorGradient}. */
+  private int[] colorGradientArgb;
+
   /**
    * When non-null, opaque-white {@link Marker#SET} colors resolve to this instead (light canvas
    * contrast).
@@ -30,6 +33,7 @@ public class ColorGradient {
     this.markerSetColor = markerSetColor;
     this.name = name;
     this.colorGradient = this.getColorGradient(size);
+    rebuildArgbLut();
   }
 
   protected Color[] getColorGradient(int size) {
@@ -50,6 +54,21 @@ public class ColorGradient {
 
   public void updateGradient(int size) {
     colorGradient = getColorGradient(size);
+    rebuildArgbLut();
+  }
+
+  private void rebuildArgbLut() {
+    Color[] gradient = colorGradient;
+    if (gradient == null) {
+      colorGradientArgb = null;
+      return;
+    }
+    int[] argb = new int[gradient.length];
+    for (int i = 0; i < gradient.length; i++) {
+      Color c = gradient[i];
+      argb[i] = c != null ? c.getRGB() : 0xFF000000;
+    }
+    colorGradientArgb = argb;
   }
 
   public Color getMarkerColor(int index, Marker m) {
@@ -69,6 +88,30 @@ public class ColorGradient {
       return effectiveMarkerSetColor();
     } else {
       return Color.BLACK;
+    }
+  }
+
+  /**
+   * Same resolution as {@link #getMarkerColor} but returns packed ARGB without allocating or boxing
+   * through {@link Color#getRGB()} on the hot path.
+   */
+  public int getMarkerArgb(int index, Marker m) {
+    if (m == Marker.NORMAL) {
+      int[] argb = colorGradientArgb;
+      if (argb == null || argb.length == 0) {
+        return 0xFF000000;
+      }
+      int i = index;
+      if (i < 0) {
+        i = 0;
+      } else if (i >= argb.length) {
+        i = argb.length - 1;
+      }
+      return argb[i];
+    } else if (m == Marker.SET) {
+      return effectiveMarkerSetColor().getRGB();
+    } else {
+      return 0xFF000000;
     }
   }
 

--- a/src/test/java/io/github/compilerstuck/control/model/EqualizeSortDurationSessionTest.java
+++ b/src/test/java/io/github/compilerstuck/control/model/EqualizeSortDurationSessionTest.java
@@ -167,17 +167,25 @@ class EqualizeSortDurationSessionTest {
   @DisplayName("Bubble Sort visual steps differ strongly by shuffle type")
   void bubbleStepsVaryByShuffle() {
     int n = 40;
+    // Deterministic stand-ins for ALMOST_SORTED / REVERSE: Math.random() almost-sorted swaps
+    // make a fixed 5× ratio flaky, while reverse is always n(n-1)/2 Bubble swaps.
     ArrayController almost = new ArrayController(n);
-    almost.setShuffleType(ShuffleType.ALMOST_SORTED);
-    shuffleSilent(almost);
+    int[] a = almost.getArray();
+    int nearSortedSwaps = Math.max(1, n / 10);
+    for (int i = 0; i < nearSortedSwaps; i++) {
+      int idx = 5 + i * 8;
+      int tmp = a[idx];
+      a[idx] = a[idx + 1];
+      a[idx + 1] = tmp;
+    }
 
     ArrayController reverse = new ArrayController(n);
-    reverse.setShuffleType(ShuffleType.REVERSE);
-    shuffleSilent(reverse);
+    reverseInPlace(reverse);
 
     long almostSteps = countSteps(new BubbleSort(almost), almost);
     long reverseSteps = countSteps(new BubbleSort(reverse), reverse);
 
+    assertEquals(n * (n - 1L) / 2, reverseSteps);
     assertTrue(
         reverseSteps > almostSteps * 5, () -> "reverse=" + reverseSteps + " almost=" + almostSteps);
   }
@@ -409,12 +417,6 @@ class EqualizeSortDurationSessionTest {
     algorithm.setDelay(true);
     algorithm.sort();
     return counter.stepCount();
-  }
-
-  private static void shuffleSilent(ArrayController model) {
-    model.setDelayContext(NO_OP);
-    model.setOperationReporter(OperationReporter.NOOP);
-    model.shuffle();
   }
 
   private static void reverseInPlace(ArrayController model) {


### PR DESCRIPTION
## Summary
- Introduced cached render buffers and ARGB color lookup tables across visualizations to avoid per-frame allocations during rendering.
- Optimized hot-path operations in disparity and hoop visualizers.
- Cleaned up test flakiness and verified build via `./mvnw clean verify`.

## Test plan
- Ran full headless verification (`./mvnw clean verify`) including spotless formatting check.