### PR TITLE
fix: include OpenJFX win/mac natives in release JAR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,9 @@ java --enable-native-access=ALL-UNNAMED \
   -jar target/sorting-visualizer-jar-with-dependencies.jar
 ```
 
-`-Prelease` also writes a CycloneDX SBOM to `target/bom.json`.
+`-Prelease` also writes a CycloneDX SBOM to `target/bom.json`, and pulls OpenJFX
+`javafx-graphics` natives for **win / linux / mac** so the Linux-built fat JAR runs on
+those desktops (host-only resolution would ship Linux `.so` files alone).
 
 Linux app-image (requires JDK `jpackage`, Linux host):
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,7 @@ Requires **[JDK 26+](https://jdk.java.net/26/)**.
 Download [`sorting-visualizer.jar`](https://github.com/66-m/sorting-visualizer/releases/latest/download/sorting-visualizer.jar), then:
 
 ```sh
-java --enable-native-access=ALL-UNNAMED \
-  --add-opens=java.desktop/com.sun.media.sound=ALL-UNNAMED \
-  -jar sorting-visualizer.jar
+java --enable-native-access=ALL-UNNAMED --add-opens=java.desktop/com.sun.media.sound=ALL-UNNAMED -jar sorting-visualizer.jar
 ```
 
 Optional flags (after the JAR name; `fullscreen` wins over `portrait`):

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,35 @@
     <profiles>
         <profile>
             <id>release</id>
+            <!--
+              OpenJFX resolves only the *host* platform classifier by default. Releases are built
+              on Linux, so the fat JAR would otherwise ship libglass.so / GTK only and fail on
+              Windows/macOS at Platform.startup (missing glass.dll / libglass.dylib and
+              com.sun.glass.ui.win|mac). Explicit classifiers match the OpenJFX cross-platform
+              fat-JAR recipe: https://openjfx.io/openjfx-docs/#modular
+              (win / linux / mac; aarch64 jars reuse the same native filenames and cannot ship
+              alongside x64 in one fat JAR.)
+            -->
+            <dependencies>
+                <dependency>
+                    <groupId>org.openjfx</groupId>
+                    <artifactId>javafx-graphics</artifactId>
+                    <version>${javafx.version}</version>
+                    <classifier>win</classifier>
+                </dependency>
+                <dependency>
+                    <groupId>org.openjfx</groupId>
+                    <artifactId>javafx-graphics</artifactId>
+                    <version>${javafx.version}</version>
+                    <classifier>linux</classifier>
+                </dependency>
+                <dependency>
+                    <groupId>org.openjfx</groupId>
+                    <artifactId>javafx-graphics</artifactId>
+                    <version>${javafx.version}</version>
+                    <classifier>mac</classifier>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
                     <plugin>
@@ -160,6 +189,9 @@
                                                 io.github.compilerstuck.control.DesktopLauncher
                                             </mainClass>
                                         </manifest>
+                                        <manifestEntries>
+                                            <Add-Opens>java.desktop/com.sun.media.sound=ALL-UNNAMED</Add-Opens>
+                                        </manifestEntries>
                                     </archive>
                                     <appendAssemblyId>true</appendAssemblyId>
                                     <descriptorRefs>


### PR DESCRIPTION
## Summary
- Embed OpenJFX `javafx-graphics` natives for **win / linux / mac** in the `-Prelease` fat JAR so Linux CI builds run on Windows/macOS
- Add `Add-Opens` to the release assembly manifest (MIDI SoftSynthesizer path)
- Document the cross-platform native packaging and use a one-line launch command (Windows-friendly)

Fixes #70

## Test plan
- [x] `./mvnw -Prelease package -DskipTests` and confirm fat JAR contains `glass.dll`, `prism_d3d.dll`, and `com/sun/glass/ui/win`
- [x] Confirm `libglass.so` / `libglass.dylib` still present
- [ ] On Windows 11: run fixed release JAR with README flags and confirm Settings + visualization open
- [ ] Optional: `build.cmd` / `run.cmd` from source on Windows still works